### PR TITLE
Make spinner and output printing optional

### DIFF
--- a/news/12.feature
+++ b/news/12.feature
@@ -1,0 +1,1 @@
+Made ``yaspin`` an optional dependency which can be added as an extra by using ``pip install vistir[spinner]`` and can be toggled with ``vistir.misc.run(...nospin=True)``.

--- a/news/13.feature
+++ b/news/13.feature
@@ -1,0 +1,1 @@
+Added ``verbose`` flag to ``vistir.misc.run()`` to provide a way to prevent printing all subprocess output.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,11 +33,12 @@ install_requires =
     pathlib2;python_version<"3.5"
     backports.weakref;python_version<"3.3"
     backports.shutil_get_terminal_size;python_version<"3.3"
-    yaspin
     requests
     six
 
 [options.extras_require]
+spinner =
+    yaspin
 tests =
     pytest
     pytest-xdist


### PR DESCRIPTION
- Fixes #12
- Fixes #13
- Allows spinner to be disabled with `vistir.misc.run(...nospin=True)`
- Allows printing output in real time to be disabled with
  `vistir.misc.run(verbose=False)`

Signed-off-by: Dan Ryan <dan@danryan.co>