### PR TITLE
Fix run on non-Windows environments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pathlib2;python_version<"3.5"
     backports.weakref;python_version<"3.3"
     backports.shutil_get_terminal_size;python_version<"3.3"
+    backports.shutil_which;python_version<"3.3"
     requests
     six
 

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -13,6 +13,7 @@ import six
 __all__ = [
     "Path",
     "get_terminal_size",
+    "which",
     "finalize",
     "partialmethod",
     "JSONDecodeError",
@@ -31,10 +32,11 @@ else:
 
 if sys.version_info < (3, 3):
     from backports.shutil_get_terminal_size import get_terminal_size
+    from backports.shutil_which import which
     from .backports.tempfile import NamedTemporaryFile
 else:
     from tempfile import NamedTemporaryFile
-    from shutil import get_terminal_size
+    from shutil import get_terminal_size, which
 
 try:
     from weakref import finalize

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -90,23 +90,14 @@ def _spawn_subprocess(script, env={}, block=True, cwd=None, combine_stderr=True)
         options["stdin"] = subprocess.PIPE
     if cwd:
         options["cwd"] = cwd
-    # Command not found, maybe this is a shell built-in?
+
     cmd = [command] + script.args
-    if not command:  # Try to use CreateProcess directly if possible.
+    if not command:
+        # Unable to execute the command directly, try shell mode.
         cmd = script.cmdify()
         options["shell"] = True
 
-    # Try to use CreateProcess directly if possible. Specifically catch
-    # Windows error 193 "Command is not a valid Win32 application" to handle
-    # a "command" that is non-executable. See pypa/pipenv#2727.
-    try:
-        return subprocess.Popen(cmd, **options)
-    except WindowsError as e:
-        if e.winerror != 193:
-            raise
-    options["shell"] = True
-    # Try shell mode to use Windows's file association for file launch.
-    return subprocess.Popen(script.cmdify(), **options)
+    return subprocess.Popen(cmd, **options)
 
 
 def _create_subprocess(

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -14,7 +14,7 @@ from functools import partial
 import six
 
 from .cmdparse import Script
-from .compat import Path, fs_str, partialmethod
+from .compat import Path, fs_str, partialmethod, which
 
 
 __all__ = [
@@ -76,9 +76,7 @@ def dedup(iterable):
 
 
 def _spawn_subprocess(script, env={}, block=True, cwd=None, combine_stderr=True):
-    from distutils.spawn import find_executable
-
-    command = find_executable(script.command)
+    command = which(script.command)
     options = {
         "env": env,
         "universal_newlines": True,


### PR DESCRIPTION
- Simplifies subprocess spawning, getting rid of the WindowsError and still supporting builtins and Window's file associations for file launch.
- Use shutil.which for more accurate executable finding.

Fixes #18.