### PR TITLE
 Fix spinner and encoding issues

### DIFF
--- a/news/26.feature.rst
+++ b/news/26.feature.rst
@@ -1,0 +1,1 @@
+Implemented ``vistir.misc.create_tracked_tempdir``, which allows for automatically cleaning up resources using weakreferences at interpreter exit.

--- a/news/27.bugfix.rst
+++ b/news/27.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with string encodings for terminal colors when using spinners.

--- a/news/28.bugfix.rst
+++ b/news/28.bugfix.rst
@@ -1,0 +1,1 @@
+Modified spinners to prefer to write to ``sys.stderr`` by default and to avoid writing ``None``, fixed an issue with signal registration on Windows.

--- a/src/vistir/__init__.py
+++ b/src/vistir/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from .compat import NamedTemporaryFile, TemporaryDirectory, partialmethod
+from .compat import NamedTemporaryFile, TemporaryDirectory, partialmethod, to_native_string
 from .contextmanagers import (
     atomic_open_for_write,
     cd,
@@ -37,5 +37,6 @@ __all__ = [
     "VistirSpinner",
     "create_spinner",
     "create_tracked_tempdir",
-    "create_tracked_tempfile"
+    "create_tracked_tempfile",
+    "to_native_string"
 ]

--- a/src/vistir/backports/tempfile.py
+++ b/src/vistir/backports/tempfile.py
@@ -194,6 +194,8 @@ def NamedTemporaryFile(
     flags = _bin_openflags
     # Setting O_TEMPORARY in the flags causes the OS to delete
     # the file when it is closed.  This is only supported by Windows.
+    if not wrapper_class_override:
+        wrapper_class_override = _TemporaryFileWrapper
     if os.name == "nt" and delete:
         flags |= os.O_TEMPORARY
     if sys.version_info < (3, 5):
@@ -205,7 +207,9 @@ def NamedTemporaryFile(
             fd, mode, buffering=buffering, newline=newline, encoding=encoding
         )
         if wrapper_class_override is not None:
-            return wrapper_class_override(file, name, delete)
+            return type(
+                str("_TempFileWrapper"), (wrapper_class_override, object), {}
+            )(file, name, delete)
         else:
             return _TemporaryFileWrapper(file, name, delete)
 

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -24,6 +24,7 @@ __all__ = [
     "lru_cache",
     "TemporaryDirectory",
     "NamedTemporaryFile",
+    "to_native_string",
 ]
 
 if sys.version_info >= (3, 5):
@@ -142,3 +143,10 @@ def fs_str(string):
 
 
 _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+
+
+def to_native_string(string):
+    from .misc import to_text, to_bytes
+    if six.PY2:
+        return to_bytes(string)
+    return to_text(string)

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -118,15 +118,19 @@ def spinner(spinner_name=None, start_text=None, handler_map=None, nospin=False):
     """
 
     from .spin import create_spinner
-    if nospin is False:
-        try:
-            import yaspin
-        except ImportError:
+    has_yaspin = False
+    try:
+        import yaspin
+    except ImportError:
+        if not nospin:
             raise RuntimeError(
                 "Failed to import spinner! Reinstall vistir with command:"
                 " pip install --upgrade vistir[spinner]"
             )
+        else:
+            spinner_name = ""
     else:
+        has_yaspin = True
         spinner_name = ""
     if not start_text and nospin is False:
         start_text = "Running..."
@@ -135,6 +139,7 @@ def spinner(spinner_name=None, start_text=None, handler_map=None, nospin=False):
         text=start_text,
         handler_map=handler_map,
         nospin=nospin,
+        use_yaspin=has_yaspin
     ) as _spinner:
         yield _spinner
 

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -118,7 +118,6 @@ def spinner(spinner_name=None, start_text=None, handler_map=None, nospin=False):
     """
 
     from .spin import create_spinner
-    spinner_func = create_spinner
     if nospin is False:
         try:
             import yaspin
@@ -128,10 +127,10 @@ def spinner(spinner_name=None, start_text=None, handler_map=None, nospin=False):
                 " pip install --upgrade vistir[spinner]"
             )
     else:
-        spinner_name = None
+        spinner_name = ""
     if not start_text and nospin is False:
         start_text = "Running..."
-    with spinner_func(
+    with create_spinner(
         spinner_name=spinner_name,
         text=start_text,
         handler_map=handler_map,
@@ -271,8 +270,8 @@ def open_file(link, session=None, stream=True):
                 result = raw if raw else resp
                 yield result
             finally:
-                result.close()
                 if raw:
                     conn = getattr(raw, "_connection")
                     if conn is not None:
                         conn.close()
+                result.close()

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -293,9 +293,7 @@ def run(
         cmd = Script.parse(cmd)
     if block or not return_object:
         combine_stderr = False
-    start_text = "Running..."
-    if nospin and not start_text:
-        start_text = ""
+    start_text = ""
     with spinner(spinner_name=spinner_name, start_text=start_text, nospin=nospin) as sp:
         return _create_subprocess(
             cmd,

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -294,8 +294,8 @@ def run(
     if block or not return_object:
         combine_stderr = False
     start_text = "Running..."
-    if nospin:
-        start_text = None
+    if nospin and not start_text:
+        start_text = ""
     with spinner(spinner_name=spinner_name, start_text=start_text, nospin=nospin) as sp:
         return _create_subprocess(
             cmd,

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -15,7 +15,7 @@ from itertools import islice
 import six
 
 from .cmdparse import Script
-from .compat import Path, fs_str, partialmethod
+from .compat import Path, fs_str, partialmethod, to_native_string
 from .contextmanagers import spinner as spinner
 
 if os.name != "nt":
@@ -145,7 +145,8 @@ def _create_subprocess(
     verbose=False,
     spinner=None,
     combine_stderr=False,
-    display_limit=200
+    display_limit=200,
+    start_text=""
 ):
     if not env:
         env = {}
@@ -157,13 +158,13 @@ def _create_subprocess(
         raise
     if not block:
         c.stdin.close()
-        log_level = "DEBUG" if verbose else "ERROR"
-        logger = _get_logger(cmd._parts[0], level=log_level)
         output = []
         err = []
-        spinner_orig_text = ""
+        spinner_orig_text = None
         if spinner:
-            spinner_orig_text = getattr(spinner, "text", "")
+            spinner_orig_text = getattr(spinner, "text", None)
+        if spinner_orig_text is None:
+            spinner_orig_text = start_text if start_text is not None else ""
         streams = {
             "stdout": c.stdout,
             "stderr": c.stderr
@@ -185,25 +186,32 @@ def _create_subprocess(
                     stdout_line = line
             if not (stdout_line or stderr_line):
                 break
-            if stderr_line:
+            if stderr_line is not None:
                 err.append(stderr_line)
-                if verbose:
+                err_line = fs_str("{0}".format(stderr_line))
+                if verbose and err_line is not None:
                     if spinner:
-                        spinner.write_err(fs_str(stderr_line))
+                        spinner._hide_cursor()
+                        spinner.write_err(err_line)
+                        spinner._show_cursor()
                     else:
-                        logger.error(stderr_line)
-            if stdout_line:
+                        sys.stderr.write(err_line)
+                        sys.stderr.flush()
+            if stdout_line is not None:
                 output.append(stdout_line)
-                display_line = stdout_line
+                display_line = fs_str("{0}".format(stdout_line))
                 if len(stdout_line) > display_limit:
                     display_line = "{0}...".format(stdout_line[:display_limit])
-                if verbose:
+                if verbose and display_line is not None:
                     if spinner:
-                        spinner.write_err(fs_str(display_line))
+                        spinner._hide_cursor()
+                        spinner.write_err(display_line)
+                        spinner._show_cursor()
                     else:
-                        logger.debug(display_line)
+                        sys.stderr.write(display_line)
+                        sys.stderr.flush()
                 if spinner:
-                    spinner.text = fs_str("{0} {1}".format(spinner_orig_text, display_line))
+                    spinner.text = to_native_string("{0} {1}".format(spinner_orig_text, display_line))
                 continue
         try:
             c.wait()
@@ -214,21 +222,19 @@ def _create_subprocess(
                 c.stderr.close()
         if spinner:
             if c.returncode > 0:
-                spinner.fail("Failed...cleaning up...")
-            else:
-                spinner.text = "Complete!"
+                spinner.fail(to_native_string("Failed...cleaning up..."))
             if not os.name == "nt":
-                spinner.ok("✔")
+                spinner.ok(to_native_string("✔ Complete"))
             else:
-                spinner.ok()
-        c.out = "\n".join(output)
+                spinner.ok(to_native_string("Complete"))
+        c.out = "\n".join(output) if output else ""
         c.err = "\n".join(err) if err else ""
     else:
         c.out, c.err = c.communicate()
     if not block:
         c.wait()
-    c.out = fs_str("{0}".format(c.out)) if c.out else fs_str("")
-    c.err = fs_str("{0}".format(c.err)) if c.err else fs_str("")
+    c.out = to_text("{0}".format(c.out)) if c.out else fs_str("")
+    c.err = to_text("{0}".format(c.err)) if c.err else fs_str("")
     if not return_object:
         return c.out.strip(), c.err.strip()
     return c
@@ -299,7 +305,8 @@ def run(
             cwd=cwd,
             verbose=verbose,
             spinner=sp,
-            combine_stderr=combine_stderr
+            combine_stderr=combine_stderr,
+            start_text=start_text
         )
 
 

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -457,7 +457,7 @@ def safe_expandvars(value):
     return value
 
 
-class _TrackedTempfileWrapper(_TemporaryFileWrapper):
+class _TrackedTempfileWrapper(_TemporaryFileWrapper, object):
     def __init__(self, *args, **kwargs):
         super(_TrackedTempfileWrapper, self).__init__(*args, **kwargs)
         self._finalizer = finalize(self, self.cleanup)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -46,7 +46,7 @@ __all__ = [
 ]
 
 
-if os.name == "nt" and six.PY34:
+if os.name == "nt":
     warnings.filterwarnings("ignore", category=DeprecationWarning, message="The Windows bytes API has been deprecated.*")
 
 
@@ -316,8 +316,7 @@ def handle_remove_readonly(func, path, exc):
     :func:`set_write_bit` on the target path and try again.
     """
     # Check for read-only attribute
-    if six.PY2:
-        from .compat import ResourceWarning
+    from .compat import ResourceWarning
     from .misc import to_bytes
 
     PERM_ERRORS = (errno.EACCES, errno.EPERM)

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -36,7 +36,7 @@ class DummySpinner(object):
         self.stderr = kwargs.get("stderr", sys.stderr)
 
     def __enter__(self):
-        if self.text:
+        if self.text and self.text != "None":
             self.write_err(self.text)
         return self
 
@@ -58,12 +58,12 @@ class DummySpinner(object):
             return retval
 
     def fail(self, exitcode=1, text="FAIL"):
-        if text:
+        if text and text != "None":
             self.write_err(text)
         raise SystemExit(exitcode, text)
 
     def ok(self, text="OK"):
-        if text:
+        if text and text != "None":
             self.stderr.write(self.text)
         return 0
 
@@ -251,6 +251,7 @@ class VistirSpinner(base_obj):
 
 def create_spinner(*args, **kwargs):
     nospin = kwargs.pop("nospin", False)
+    use_yaspin = kwargs.pop("use_yaspin", nospin)
     if nospin:
         return DummySpinner(*args, **kwargs)
     return VistirSpinner(*args, **kwargs)

--- a/src/vistir/termcolors.py
+++ b/src/vistir/termcolors.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import colorama
 import os
+from .compat import to_native_string
 
 
 ATTRIBUTES = dict(
@@ -53,6 +54,33 @@ COLORS = dict(
         )
 
 
+COLOR_MAP = {
+    # name: type
+    "blink": "attrs",
+    "bold": "attrs",
+    "concealed": "attrs",
+    "dark": "attrs",
+    "reverse": "attrs",
+    "underline": "attrs",
+    "blue": "color",
+    "cyan": "color",
+    "green": "color",
+    "magenta": "color",
+    "red": "color",
+    "white": "color",
+    "yellow": "color",
+    "on_blue": "on_color",
+    "on_cyan": "on_color",
+    "on_green": "on_color",
+    "on_grey": "on_color",
+    "on_magenta": "on_color",
+    "on_red": "on_color",
+    "on_white": "on_color",
+    "on_yellow": "on_color",
+}
+COLOR_ATTRS = COLOR_MAP.keys()
+
+
 RESET = colorama.Style.RESET_ALL
 
 
@@ -80,25 +108,25 @@ def colored(text, color=None, on_color=None, attrs=None):
             attrs.remove('bold')
         if color is not None:
             color = color.upper()
-            text = text = "%s%s%s%s%s" % (
-                getattr(colorama.Fore, color),
-                getattr(colorama.Style, style),
-                text,
-                colorama.Fore.RESET,
-                colorama.Style.NORMAL,
+            text = to_native_string("%s%s%s%s%s") % (
+                to_native_string(getattr(colorama.Fore, color)),
+                to_native_string(getattr(colorama.Style, style)),
+                to_native_string(text),
+                to_native_string(colorama.Fore.RESET),
+                to_native_string(colorama.Style.NORMAL),
             )
 
         if on_color is not None:
             on_color = on_color.upper()
-            text = "%s%s%s%s" % (
-                getattr(colorama.Back, on_color),
-                text,
-                colorama.Back.RESET,
-                colorama.Style.NORMAL,
+            text = to_native_string("%s%s%s%s") % (
+                to_native_string(getattr(colorama.Back, on_color)),
+                to_native_string(text),
+                to_native_string(colorama.Back.RESET),
+                to_native_string(colorama.Style.NORMAL),
             )
 
         if attrs is not None:
-            fmt_str = "%s[%%dm%%s%s[9m" % (
+            fmt_str = to_native_string("%s[%%dm%%s%s[9m") % (
                 chr(27),
                 chr(27)
             )


### PR DESCRIPTION
- Modified spinners to prefer to write to ``sys.stderr`` by default
- avoid writing ``None``
- fixed an issue with signal registration on Windows
- Fixed a bug with string encodings for terminal colors when using
  spinners
- Implemented ``vistir.misc.create_tracked_tempdir``, which allows for
  automatically cleaning up resources using weakreferences at interpreter exit.
- Fixes #26
- Fixes #27
- Fixes #28