### PR TITLE
Backport new readonly removal features from python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,11 +113,14 @@ Shims are provided for full API compatibility from python 2.7 through 3.7 for th
     * ``vistir.compat.JSONDecodeError``
     * ``vistir.compat.ResourceWarning``
     * ``vistir.compat.FileNotFoundError``
+    * ``vistir.compat.PermissionError``
+    * ``vistir.compat.IsADirectoryError``
 
-The following additional function is provided for encoding strings to the filesystem
-defualt encoding:
+The following additional functions are provided for encoding strings to the filesystem
+default encoding:
 
     * ``vistir.compat.fs_str``
+    * ``vistir.compat.to_native_string``
 
 
 🐉 Context Managers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,9 @@
 #
 import os
 import sys
-sys.path.insert(0, '/home/hawk/git/vistir/src/vistir')
+docs_dir = os.path.abspath(os.path.dirname(__file__))
+src_dir = os.path.join(os.path.dirname(docs_dir), "src", "vistir")
+sys.path.insert(0, src_dir)
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,7 +29,7 @@ Install from `PyPI`_:
 
   ::
 
-    $ pipenv install --pre vistir
+    $ pipenv install vistir
 
 Install from `Github`_:
 
@@ -113,11 +113,14 @@ Shims are provided for full API compatibility from python 2.7 through 3.7 for th
     * :class:`~vistir.compat.JSONDecodeError`
     * :exc:`~vistir.compat.ResourceWarning`
     * :exc:`~vistir.compat.FileNotFoundError`
+    * :exc:`~vistir.compat.PermissionError`
+    * :exc:`~vistir.compat.IsADirectoryError`
 
 The following additional function is provided for encoding strings to the filesystem
 defualt encoding:
 
     * :func:`~vistir.compat.fs_str`
+    * :func:`~vistir.compat.to_native_string`
 
 
 🐉 Context Managers

--- a/news/38.feature.rst
+++ b/news/38.feature.rst
@@ -1,0 +1,1 @@
+Backported compatibility shims from ``CPython`` for improved cleanup of readonly temporary directories on cleanup.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vistir
-description = Setup / utilities which most projects eventually need
+description = Miscellaneous utilities for dealing with filesystems, paths, projects, subprocesses, and more.
 url = https://github.com/sarugaku/vistir
 author = Dan Ryan
 author_email = dan@danryan.co
@@ -12,6 +12,9 @@ keywords =
     utilities
     backports
     paths
+    spinner
+    subprocess
+    filesystem
 
 classifier =
     Development Status :: 3 - Alpha
@@ -31,7 +34,7 @@ python_requires = >=2.6,!=3.0,!=3.1,!=3.2,!=3.3
 setup_requires = setuptools>=36.2.2
 install_requires =
     pathlib2;python_version<"3.5"
-    backports.functools_lru_cache; python_version <= "3.4"
+    backports.functools_lru_cache;python_version <= "3.4"
     backports.shutil_get_terminal_size;python_version<"3.3"
     backports.weakref;python_version<"3.3"
     requests
@@ -88,4 +91,4 @@ ignore =
     # E231: missing whitespace after ','
     # E402: module level import not at top of file
     # E501: line too long
-    E127,E128,E129,E222,E231,E402,E501
+    E231,E402,E501

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -19,7 +19,8 @@ __all__ = [
     "JSONDecodeError",
     "FileNotFoundError",
     "ResourceWarning",
-    "FileNotFoundError",
+    "PermissionError",
+    "IsADirectoryError",
     "fs_str",
     "lru_cache",
     "TemporaryDirectory",
@@ -69,8 +70,17 @@ if six.PY2:
             self.errno = errno.ENOENT
             super(FileNotFoundError, self).__init__(*args, **kwargs)
 
+    class PermissionError(OSError):
+        def __init__(self, *args, **kwargs):
+            self.errno = errno.EACCES
+            super(PermissionError, self).__init__(*args, **kwargs)
+
+    class IsADirectoryError(OSError):
+        """The command does not work on directories"""
+        pass
+
 else:
-    from builtins import ResourceWarning, FileNotFoundError
+    from builtins import ResourceWarning, FileNotFoundError, PermissionError, IsADirectoryError
 
 
 if not sys.warnoptions:
@@ -111,9 +121,39 @@ class TemporaryDirectory(object):
         )
 
     @classmethod
-    def _cleanup(cls, name, warn_message):
+    def _rmtree(cls, name):
         from .path import rmtree
-        rmtree(name)
+
+        def onerror(func, path, exc_info):
+            if issubclass(exc_info[0], (PermissionError, OSError)):
+                try:
+                    try:
+                        if path != name:
+                            os.chflags(os.path.dirname(path), 0)
+                        os.chflags(path, 0)
+                    except AttributeError:
+                        pass
+                    if path != name:
+                        os.chmod(os.path.dirname(path), 0o70)
+                    os.chmod(path, 0o700)
+
+                    try:
+                        os.unlink(path)
+                    # PermissionError is raised on FreeBSD for directories
+                    except (IsADirectoryError, PermissionError, OSError):
+                        cls._rmtree(path)
+                except FileNotFoundError:
+                    pass
+            elif issubclass(exc_info[0], FileNotFoundError):
+                pass
+            else:
+                raise
+
+        rmtree(name, onerror=onerror)
+
+    @classmethod
+    def _cleanup(cls, name, warn_message):
+        cls._rmtree(name)
         warnings.warn(warn_message, ResourceWarning)
 
     def __repr__(self):
@@ -126,9 +166,8 @@ class TemporaryDirectory(object):
         self.cleanup()
 
     def cleanup(self):
-        from .path import rmtree
         if self._finalizer.detach():
-            rmtree(self.name)
+            self._rmtree(self.name)
 
 
 def fs_str(string):
@@ -136,6 +175,7 @@ def fs_str(string):
 
     Borrowed from pip-tools
     """
+
     if isinstance(string, str):
         return string
     assert not isinstance(string, bytes)

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -494,7 +494,6 @@ except Exception:
 def getpreferredencoding():
     """Determine the proper output encoding for terminal rendering"""
 
-    import locale
     # Borrowed from Invoke
     # (see https://github.com/pyinvoke/invoke/blob/93af29d/invoke/runners.py#L881)
     _encoding = locale.getpreferredencoding(False)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 
 import atexit
 import errno

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -292,6 +292,6 @@ class VistirSpinner(base_obj):
 def create_spinner(*args, **kwargs):
     nospin = kwargs.pop("nospin", False)
     use_yaspin = kwargs.pop("use_yaspin", nospin)
-    if nospin:
+    if nospin or not use_yaspin:
         return DummySpinner(*args, **kwargs)
     return VistirSpinner(*args, **kwargs)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -74,7 +74,7 @@ def test_nonblocking_run():
     assert c.returncode == 0
     c.wait()
     assert "PYTHONDONTWRITEBYTECODE" in c.out, c.out
-    out, err = vistir.misc.run(["python", "--help"], block=False, nospin=True)
+    out, _ = vistir.misc.run(["python", "--help"], block=False, nospin=True)
     assert "PYTHONDONTWRITEBYTECODE" in out, out
     # historical = []
     # while out:

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 import io
 import os
-import six
 import stat
 
 from hypothesis import assume, given, HealthCheck, settings


### PR DESCRIPTION
- Backport python/cpython#10320 (not yet merged) for better cleanup on
  `shutil.rmtree` failure (using `os.chflags`)
- Add compatibility shims for `PermissionError` and `IsADirectory`
  exceptions
- General cleanup
- Fixes #38

Signed-off-by: Dan Ryan <dan@danryan.co>