### PR TITLE
Fix bugs in rmtree

### DIFF
--- a/news/46.bugfix
+++ b/news/46.bugfix
@@ -1,0 +1,1 @@
+Fix bug where FileNotFoundError is not imported from compat for rmtree

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -329,7 +329,7 @@ def rmtree(directory, ignore_errors=False, onerror=None):
        Setting `ignore_errors=True` may cause this to silently fail to delete the path
     """
 
-    from .compat import to_native_string
+    from .compat import to_native_string, FileNotFoundError
 
     directory = to_native_string(directory)
     if onerror is None:

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -340,9 +340,8 @@ def rmtree(directory, ignore_errors=False, onerror=None):
         )
     except (IOError, OSError, FileNotFoundError) as exc:
         # Ignore removal failures where the file doesn't exist
-        if exc.errno == errno.ENOENT:
-            pass
-        raise
+        if exc.errno != errno.ENOENT:
+            raise
 
 
 def handle_remove_readonly(func, path, exc):


### PR DESCRIPTION
Fix ```FileNotFoundError``` is not imported from compat for rmtree
Fix ```rmtree``` doesn't ignore file or directory not found error

Found it in https://github.com/pypa/pipenv/pull/3354