### PR TITLE
Provide a way to capture or wrap streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - "pipenv install --dev"
   - "pipenv run pip install --upgrade -e .[spinner,tests]"
 script:
-    - "pipenv run pytest -v -n auto tests/"
+    - "pipenv run pytest -v tests/"
 
 jobs:
   include:
@@ -33,7 +33,7 @@ jobs:
     - stage: coverage
       python: "3.6"
       install:
-        - "pip install --upgrade pip pipenv pytest-cov pytest-xdist pytest-timeout pytest"
+        - "pip install --upgrade pip pipenv pytest-cov pytest-timeout pytest"
         - "pipenv install --dev"
       script:
-        - "pipenv run pytest -n auto --timeout 300 --cov=vistir --cov-report=term-missing --cov-report=xml --cov-report=html tests"
+        - "pipenv run pytest --timeout 300 --cov=vistir --cov-report=term-missing --cov-report=xml --cov-report=html tests"

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ default encoding:
     * ``vistir.contextmanagers.atomic_open_for_write``
     * ``vistir.contextmanagers.cd``
     * ``vistir.contextmanagers.open_file``
+    * ``vistir.contextmanagers.replaced_stream``
     * ``vistir.contextmanagers.spinner``
     * ``vistir.contextmanagers.temp_environ``
     * ``vistir.contextmanagers.temp_path``
@@ -201,6 +202,23 @@ to pair this with an iterator which employs a sensible chunk size.
     >>> filecontents = io.BytesIO(b"")
     >>> with vistir.contextmanagers.open_file("https://norvig.com/big.txt") as fp:
             shutil.copyfileobj(fp, filecontents)
+
+
+.. _`replaced_stream`:
+
+A context manager to temporarily swap out *stream_name* with a stream wrapper.  This will
+capture the stream output and prevent it from being written as normal.
+
+.. code-block:: python
+
+    >>> orig_stdout = sys.stdout
+    >>> with replaced_stream("stdout") as stdout:
+    ...     sys.stdout.write("hello")
+    ...     assert stdout.getvalue() == "hello"
+    ...     assert orig_stdout.getvalue() != "hello"
+
+    >>> sys.stdout.write("hello")
+    'hello'
 
 
 .. _`spinner`:
@@ -286,8 +304,13 @@ The following Miscellaneous utilities are available as helper methods:
     * ``vistir.misc.partialclass``
     * ``vistir.misc.to_text``
     * ``vistir.misc.to_bytes``
+    * ``vistir.misc.divide``
+    * ``vistir.misc.take``
+    * ``vistir.misc.chunked``
     * ``vistir.misc.decode_for_output``
-
+    * ``vistir.misc.get_canonical_encoding_name``
+    * ``vistir.misc.get_wrapped_stream``
+    * ``vistir.misc.StreamWrapper``
 
 .. _`shell_escape`:
 
@@ -401,6 +424,62 @@ Converts arbitrary byte-convertable input to bytes while handling errors.
     b'this is some text'
 
 
+.. _`chunked`:
+
+**chunked**
+////////////
+
+Splits an iterable up into groups *of the specified length*, per `more itertools`_.  Returns an iterable.
+
+This example will create groups of chunk size **5**, which means there will be *6 groups*.
+
+.. code-block:: python
+
+    >>> chunked_iterable = vistir.misc.chunked(5, range(30))
+    >>> for chunk in chunked_iterable:
+    ...     add_to_some_queue(chunk)
+
+.. _more itertools: https://more-itertools.readthedocs.io/en/latest/api.html#grouping
+
+
+.. _`take`:
+
+**take**
+/////////
+
+Take elements from the supplied iterable without consuming it.
+
+.. code-block:: python
+
+    >>> iterable = range(30)
+    >>> first_10 = take(10, iterable)
+    >>> [i for i in first_10]
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    >>> [i for i in iterable]
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+
+
+.. _`divide`:
+
+**divide**
+////////////
+
+Splits an iterable up into the *specified number of groups*, per `more itertools`_.  Returns an iterable.
+
+.. code-block:: python
+
+    >>> iterable = range(30)
+    >>> groups = []
+    >>> for grp in vistir.misc.divide(3, iterable):
+    ...     groups.append(grp)
+    >>> groups
+    [<tuple_iterator object at 0x7fb7966006a0>, <tuple_iterator object at 0x7fb796652780>, <tuple_iterator object at 0x7fb79650a2b0>]
+
+
+.. _more itertools: https://more-itertools.readthedocs.io/en/latest/api.html#grouping
+
+
 .. _`decode_for_output`:
 
 **decode_for_output**
@@ -409,6 +488,46 @@ Converts arbitrary byte-convertable input to bytes while handling errors.
 Converts an arbitrary text input to output which is encoded for printing to terminal
 outputs using the system preferred locale using ``locale.getpreferredencoding(False)``
 with some additional hackery on linux systems.
+
+
+.. _`get_canonical_encoding_name`:
+
+**get_canonical_encoding_name**
+////////////////////////////////
+
+Given an encoding name, get the canonical name from a codec lookup.
+
+.. code-block:: python
+
+    >>> vistir.misc.get_canonical_encoding_name("utf8")
+    "utf-8"
+
+
+.. _`get_wrapped_stream`:
+
+**get_wrapped_stream**
+//////////////////////
+
+Given a stream, wrap it in a `StreamWrapper` instance and return the wrapped stream.
+
+.. code-block:: python
+
+    >>> stream = sys.stdout
+    >>> wrapped_stream = vistir.misc.get_wrapped_stream(sys.stdout)
+
+
+.. _`StreamWrapper`:
+
+**StreamWrapper**
+//////////////////
+
+A stream wrapper and compatibility class for handling wrapping file-like stream objects
+which may be used in place of ``sys.stdout`` and other streams.
+
+.. code-block:: python
+
+    >>> wrapped_stream = vistir.misc.StreamWrapper(sys.stdout, encoding="utf-8", errors="replace", line_buffering=True)
+    >>> wrapped_stream = vistir.misc.StreamWrapper(io.StringIO(), encoding="utf-8", errors="replace", line_buffering=True)
 
 
 🐉 Path Utilities

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ environment:
 install:
   - "SET PATH=%PYTHON%\\;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
-  - "python -m pip install --upgrade pip pipenv"
+  - "python -m pip install --upgrade pip pipenv pytest pytest-timeout pytest-cov"
   - "python -m pipenv install --dev"
-  - "python -m pipenv run pip install -e .[tests,spinner]"
+  - "python -m pipenv run pip install --upgrade -e .[tests,spinner]"
 
 build: off
 
@@ -24,4 +24,4 @@ test_script:
   - "subst T: %TEMP%"
   - "set TEMP=T:\\"
   - "set TMP=T:\\"
-  - "python -m pipenv run pytest -n auto -v tests"
+  - "python -m pipenv run pytest -ra tests"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,11 +12,30 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import codecs
 import os
+import re
 import sys
 docs_dir = os.path.abspath(os.path.dirname(__file__))
 src_dir = os.path.join(os.path.dirname(docs_dir), "src", "vistir")
 sys.path.insert(0, src_dir)
+version_file = os.path.join(src_dir, "__init__.py")
+
+
+def read_file(path):
+    # intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with codecs.open(path, 'r') as fp:
+        return fp.read()
+
+
+def find_version(file_path):
+    version_file = read_file(file_path)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    return '0.0.0'
 
 
 # -- Project information -----------------------------------------------------
@@ -25,10 +44,12 @@ project = 'vistir'
 copyright = '2018, Dan Ryan <dan@danryan.co>'
 author = 'Dan Ryan <dan@danryan.co>'
 
+release = find_version(version_file)
+version = '.'.join(release.split('.')[:2])
 # The short X.Y version
-version = '0.0'
+# version = '0.0'
 # The full version, including alpha/beta/rc tags
-release = '0.0.0.dev0'
+# release = '0.0.0.dev0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -132,11 +153,11 @@ html_theme_options = {
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
-    # 'papersize': 'letterpaper',
+    'papersize': 'letterpaper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #
-    # 'pointsize': '10pt',
+    'pointsize': '10pt',
 
     # Additional stuff for the LaTeX preamble.
     #
@@ -173,7 +194,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'vistir', 'vistir Documentation',
-     author, 'vistir', 'One line description of project.',
+     author, 'vistir', 'Miscellaneous utilities for dealing with filesystems, paths, projects, subprocesses, and more.',
      'Miscellaneous'),
 ]
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -215,7 +215,6 @@ capture the stream output and prevent it from being written as normal.
     >>> with replaced_stream("stdout") as stdout:
     ...     sys.stdout.write("hello")
     ...     assert stdout.getvalue() == "hello"
-    ...     assert orig_stdout.getvalue() != "hello"
 
     >>> sys.stdout.write("hello")
     'hello'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,6 +131,7 @@ defualt encoding:
     * :func:`~vistir.contextmanagers.atomic_open_for_write`
     * :func:`~vistir.contextmanagers.cd`
     * :func:`~vistir.contextmanagers.open_file`
+    * :func:`~vistir.contextmanagers.replaced_stream`
     * :func:`~vistir.contextmanagers.spinner`
     * :func:`~vistir.contextmanagers.temp_environ`
     * :func:`~vistir.contextmanagers.temp_path`
@@ -201,6 +202,23 @@ to pair this with an iterator which employs a sensible chunk size.
     >>> filecontents = io.BytesIO(b"")
     >>> with vistir.contextmanagers.open_file("https://norvig.com/big.txt") as fp:
             shutil.copyfileobj(fp, filecontents)
+
+
+.. _`replaced_stream`:
+
+A context manager to temporarily swap out *stream_name* with a stream wrapper.  This will
+capture the stream output and prevent it from being written as normal.
+
+.. code-block:: python
+
+    >>> orig_stdout = sys.stdout
+    >>> with replaced_stream("stdout") as stdout:
+    ...     sys.stdout.write("hello")
+    ...     assert stdout.getvalue() == "hello"
+    ...     assert orig_stdout.getvalue() != "hello"
+
+    >>> sys.stdout.write("hello")
+    'hello'
 
 
 .. _`spinner`:
@@ -286,7 +304,13 @@ The following Miscellaneous utilities are available as helper methods:
     * :func:`~vistir.misc.partialclass`
     * :func:`~vistir.misc.to_text`
     * :func:`~vistir.misc.to_bytes`
+    * :func:`~vistir.misc.divide`
+    * :func:`~vistir.misc.take`
+    * :func:`~vistir.misc.chunked`
     * :func:`~vistir.misc.decode_for_output`
+    * :func:`~vistir.misc.get_canonical_encoding_name`
+    * :func:`~vistir.misc.get_wrapped_stream`
+    * :class:`~vistir.misc.StreamWrapper`
 
 
 .. _`shell_escape`:
@@ -401,6 +425,62 @@ Converts arbitrary byte-convertable input to bytes while handling errors.
     b'this is some text'
 
 
+.. _`chunked`:
+
+**chunked**
+////////////
+
+Splits an iterable up into groups *of the specified length*, per `more itertools`_.  Returns an iterable.
+
+This example will create groups of chunk size **5**, which means there will be *6 groups*.
+
+.. code-block:: python
+
+    >>> chunked_iterable = vistir.misc.chunked(5, range(30))
+    >>> for chunk in chunked_iterable:
+    ...     add_to_some_queue(chunk)
+
+.. _more itertools: https://more-itertools.readthedocs.io/en/latest/api.html#grouping
+
+
+.. _`take`:
+
+**take**
+/////////
+
+Take elements from the supplied iterable without consuming it.
+
+.. code-block:: python
+
+    >>> iterable = range(30)
+    >>> first_10 = take(10, iterable)
+    >>> [i for i in first_10]
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    >>> [i for i in iterable]
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+
+
+.. _`divide`:
+
+**divide**
+////////////
+
+Splits an iterable up into the *specified number of groups*, per `more itertools`_.  Returns an iterable.
+
+.. code-block:: python
+
+    >>> iterable = range(30)
+    >>> groups = []
+    >>> for grp in vistir.misc.divide(3, iterable):
+    ...     groups.append(grp)
+    >>> groups
+    [<tuple_iterator object at 0x7fb7966006a0>, <tuple_iterator object at 0x7fb796652780>, <tuple_iterator object at 0x7fb79650a2b0>]
+
+
+.. _more itertools: https://more-itertools.readthedocs.io/en/latest/api.html#grouping
+
+
 .. _`decode_for_output`:
 
 **decode_for_output**
@@ -414,6 +494,46 @@ with some additional hackery on linux systems.
 
     >>> vistir.misc.decode_for_output(u"Some text")
     "some default locale encoded text"
+
+
+.. _`get_canonical_encoding_name`:
+
+**get_canonical_encoding_name**
+////////////////////////////////
+
+Given an encoding name, get the canonical name from a codec lookup.
+
+.. code-block:: python
+
+    >>> vistir.misc.get_canonical_encoding_name("utf8")
+    "utf-8"
+
+
+.. _`get_wrapped_stream`:
+
+**get_wrapped_stream**
+//////////////////////
+
+Given a stream, wrap it in a `StreamWrapper` instance and return the wrapped stream.
+
+.. code-block:: python
+
+    >>> stream = sys.stdout
+    >>> wrapped_stream = vistir.misc.get_wrapped_stream(sys.stdout)
+
+
+.. _`StreamWrapper`:
+
+**StreamWrapper**
+//////////////////
+
+A stream wrapper and compatibility class for handling wrapping file-like stream objects
+which may be used in place of ``sys.stdout`` and other streams.
+
+.. code-block:: python
+
+    >>> wrapped_stream = vistir.misc.StreamWrapper(sys.stdout, encoding="utf-8", errors="replace", line_buffering=True)
+    >>> wrapped_stream = vistir.misc.StreamWrapper(io.StringIO(), encoding="utf-8", errors="replace", line_buffering=True)
 
 
 🐉 Path Utilities

--- a/news/48.feature.rst
+++ b/news/48.feature.rst
@@ -1,0 +1,3 @@
+Added a new ``vistir.misc.StreamWrapper`` class with ``vistir.misc.get_wrapped_stream()`` to wrap existing streams
+and ``vistir.contextmanagers.replaced_stream()`` to temporarily replace a stream.
+

--- a/news/49.bugfix.rst
+++ b/news/49.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with exception handling during ``_create_process`` calls.

--- a/news/51.feature.rst
+++ b/news/51.feature.rst
@@ -1,0 +1,1 @@
+Added new entries in ``vistir.compat`` to support movements to ``collections.abc``: ``Mapping``, ``Sequence``, ``Set``, ``ItemsView``.

--- a/news/52.feature.rst
+++ b/news/52.feature.rst
@@ -1,0 +1,2 @@
+Improved ``decode_for_output`` to handle decoding failures gracefully by moving to an ``replace`` strategy.
+Now also allows a translation map to be provided to translate specific non-ascii characters when writing to outputs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,18 +31,22 @@ classifier =
 [options]
 zip_safe = true
 python_requires = >=2.6,!=3.0,!=3.1,!=3.2,!=3.3
-setup_requires = setuptools>=36.2.2
+setup_requires =
+    setuptools>=38.2.5
+    invoke
+    parver
+    wheel
 install_requires =
-    pathlib2;python_version<"3.5"
+    colorama
     backports.functools_lru_cache;python_version<="3.4"
     backports.shutil_get_terminal_size;python_version<"3.3"
     backports.weakref;python_version<"3.3"
+    pathlib2;python_version<"3.5"
     requests
     six
 
 [options.extras_require]
 spinner =
-    colorama
     cursor
     yaspin
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >=2.6,!=3.0,!=3.1,!=3.2,!=3.3
 setup_requires = setuptools>=36.2.2
 install_requires =
     pathlib2;python_version<"3.5"
-    backports.functools_lru_cache;python_version <= "3.4"
+    backports.functools_lru_cache;python_version<="3.4"
     backports.shutil_get_terminal_size;python_version<"3.3"
     backports.weakref;python_version<"3.3"
     requests

--- a/src/vistir/__init__.py
+++ b/src/vistir/__init__.py
@@ -61,4 +61,8 @@ __all__ = [
     "take",
     "chunked",
     "divide",
+    "StringIO",
+    "get_wrapped_stream",
+    "StreamWrapper",
+    "replaced_stream"
 ]

--- a/src/vistir/__init__.py
+++ b/src/vistir/__init__.py
@@ -6,6 +6,7 @@ from .compat import (
     TemporaryDirectory,
     partialmethod,
     to_native_string,
+    StringIO,
 )
 from .contextmanagers import (
     atomic_open_for_write,
@@ -14,6 +15,7 @@ from .contextmanagers import (
     temp_environ,
     temp_path,
     spinner,
+    replaced_stream
 )
 from .misc import (
     load_path,
@@ -26,6 +28,8 @@ from .misc import (
     take,
     chunked,
     divide,
+    get_wrapped_stream,
+    StreamWrapper
 )
 from .path import mkdir_p, rmtree, create_tracked_tempdir, create_tracked_tempfile
 from .spin import VistirSpinner, create_spinner

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -60,6 +60,8 @@ except ImportError:  # Old Pythons.
 
 if six.PY2:
 
+    from io import BytesIO as StringIO
+
     class ResourceWarning(Warning):
         pass
 
@@ -81,7 +83,7 @@ if six.PY2:
 
 else:
     from builtins import ResourceWarning, FileNotFoundError, PermissionError, IsADirectoryError
-
+    from io import StringIO
 
 six.add_move(six.MovedAttribute("Iterable", "collections", "collections.abc"))
 from six.moves import Iterable

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import errno
 import os
@@ -86,8 +86,16 @@ if six.PY2:
         """The command does not work on directories"""
         pass
 
+    class FileExistsError(OSError):
+        def __init__(self, *args, **kwargs):
+            self.errno = errno.EEXIST
+            super(FileExistsError, self).__init__(*args, **kwargs)
+
 else:
-    from builtins import ResourceWarning, FileNotFoundError, PermissionError, IsADirectoryError
+    from builtins import (
+        ResourceWarning, FileNotFoundError, PermissionError, IsADirectoryError,
+        FileExistsError
+    )
     from io import StringIO
 
 six.add_move(six.MovedAttribute("Iterable", "collections", "collections.abc"))  # type: ignore

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -26,6 +26,11 @@ __all__ = [
     "TemporaryDirectory",
     "NamedTemporaryFile",
     "to_native_string",
+    "Iterable",
+    "Mapping",
+    "Sequence",
+    "Set",
+    "ItemsView"
 ]
 
 if sys.version_info >= (3, 5):
@@ -46,17 +51,17 @@ else:
 try:
     from weakref import finalize
 except ImportError:
-    from backports.weakref import finalize
+    from backports.weakref import finalize  # type: ignore
 
 try:
     from functools import partialmethod
 except Exception:
-    from .backports.functools import partialmethod
+    from .backports.functools import partialmethod  # type: ignore
 
 try:
     from json import JSONDecodeError
 except ImportError:  # Old Pythons.
-    JSONDecodeError = ValueError
+    JSONDecodeError = ValueError  # type: ignore
 
 if six.PY2:
 
@@ -85,9 +90,12 @@ else:
     from builtins import ResourceWarning, FileNotFoundError, PermissionError, IsADirectoryError
     from io import StringIO
 
-six.add_move(six.MovedAttribute("Iterable", "collections", "collections.abc"))
-from six.moves import Iterable
-
+six.add_move(six.MovedAttribute("Iterable", "collections", "collections.abc"))  # type: ignore
+six.add_move(six.MovedAttribute("Mapping", "collections", "collections.abc"))  # type: ignore
+six.add_move(six.MovedAttribute("Sequence", "collections", "collections.abc"))  # type: ignore
+six.add_move(six.MovedAttribute("Set", "collections", "collections.abc"))  # type: ignore
+six.add_move(six.MovedAttribute("ItemsView", "collections", "collections.abc"))  # type: ignore
+from six.moves import Iterable, Mapping, Sequence, Set, ItemsView  # type: ignore  # noqa
 
 if not sys.warnoptions:
     warnings.simplefilter("default", ResourceWarning)

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -306,7 +306,7 @@ def replaced_stream(stream_name):
     'hello'
     """
     orig_stream = getattr(sys, stream_name)
-    new_stream = StringIO()
+    new_stream = six.StringIO()
     try:
         setattr(sys, stream_name, new_stream)
         yield getattr(sys, stream_name)

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -20,7 +20,8 @@ else:
 
 
 __all__ = [
-    "temp_environ", "temp_path", "cd", "atomic_open_for_write", "open_file", "spinner", "dummy_spinner",
+    "temp_environ", "temp_path", "cd", "atomic_open_for_write", "open_file", "spinner",
+    "dummy_spinner", "replaced_stream"
 ]
 
 

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -10,13 +10,8 @@ from contextlib import contextmanager
 
 import six
 
-from .compat import NamedTemporaryFile, Path
+from .compat import NamedTemporaryFile, Path, StringIO
 from .path import is_file_url, is_valid_url, path_to_url, url_to_path
-
-if six.PY2:
-    from io import BytesIO as StringIO
-else:
-    from io import StringIO
 
 
 __all__ = [
@@ -306,20 +301,14 @@ def replaced_stream(stream_name):
     >>> with replaced_stream("stdout") as stdout:
     ...     sys.stdout.write("hello")
     ...     assert stdout.getvalue() == "hello"
-    ...     assert orig_stdout.getvalue() != "hello"
 
     >>> sys.stdout.write("hello")
     'hello'
     """
-    from .misc import StreamWrapper, get_canonical_encoding_name, PREFERRED_ENCODING
     orig_stream = getattr(sys, stream_name)
-    encoding = get_canonical_encoding_name(
-        getattr(orig_stream, encoding, PREFERRED_ENCODING)
-    )
     new_stream = StringIO()
-    wrapped_stream = StreamWrapper(new_stream, encoding, "replace", line_buffering=True)
     try:
-        setattr(sys, stream_name, wrapped_stream)
+        setattr(sys, stream_name, new_stream)
         yield getattr(sys, stream_name)
     finally:
         setattr(sys, stream_name, orig_stream)

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -312,3 +312,31 @@ def replaced_stream(stream_name):
         yield getattr(sys, stream_name)
     finally:
         setattr(sys, stream_name, orig_stream)
+
+
+@contextmanager
+def replaced_streams():
+    """
+    Context manager to replace both ``sys.stdout`` and ``sys.stderr`` using
+    ``replaced_stream``
+
+    returns: *(stdout, stderr)*
+
+    >>> import sys
+    >>> with vistir.contextmanagers.replaced_streams() as streams:
+    >>>     stdout, stderr = streams
+    >>>     sys.stderr.write("test")
+    >>>     sys.stdout.write("hello")
+    >>>     assert stdout.getvalue() == "hello"
+    >>>     assert stderr.getvalue() == "test"
+
+    >>> stdout.getvalue()
+    'hello'
+
+    >>> stderr.getvalue()
+    'test'
+    """
+
+    with replaced_stream("stdout") as stdout:
+        with replaced_stream("stderr") as stderr:
+            yield (stdout, stderr)

--- a/src/vistir/contextmanagers.py
+++ b/src/vistir/contextmanagers.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 import six
 
-from .compat import NamedTemporaryFile, Path, StringIO
+from .compat import NamedTemporaryFile, Path
 from .path import is_file_url, is_valid_url, path_to_url, url_to_path
 
 

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -163,7 +163,10 @@ def _create_subprocess(
         c = _spawn_subprocess(cmd, env=env, block=block, cwd=cwd,
                               combine_stderr=combine_stderr)
     except Exception as exc:
-        sys.stderr.write("Error %s while executing command %s", % (exc, " ".join(cmd._parts)))
+        import traceback
+        formatted_tb = "".join(traceback.format_exception(*sys.exc_info()))
+        sys.stderr.write("Error while executing command %s:" % " ".join(cmd._parts))
+        sys.stderr.write(formatted_tb)
         raise
     if not block:
         c.stdin.close()

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 
 import io
 import json

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -31,6 +31,7 @@ __all__ = [
     "get_converted_relative_path",
     "handle_remove_readonly",
     "normalize_path",
+    "is_in_path",
     "is_file_url",
     "is_readonly_path",
     "is_valid_url",

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -54,7 +54,8 @@ class DummySpinner(object):
         if exc_type:
             import traceback
             from .misc import decode_for_output
-            self.write_err(decode_for_output(traceback.format_exception(*sys.exc_info())))
+            formatted_tb = "".join(traceback.format_exception(*sys.exc_info()))
+            self.write_err(decode_for_output(formatted_tb))
         self._close_output_buffer()
         return False
 
@@ -181,7 +182,7 @@ class VistirSpinner(base_obj):
         self.out_buff = StringIO()
         self.write_to_stdout = write_to_stdout
         self.is_dummy = bool(yaspin is None)
-        if os.environ.get("ANSI_COLORS_DISABLED", False):
+        if DISABLE_COLORS:
             colorama.deinit()
         super(VistirSpinner, self).__init__(*args, **kwargs)
 

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -9,7 +9,6 @@ import threading
 import time
 
 import colorama
-import cursor
 import six
 
 from .compat import to_native_string
@@ -19,10 +18,12 @@ from io import StringIO
 
 try:
     import yaspin
+    import cursor
 except ImportError:
     yaspin = None
     Spinners = None
     SpinBase = None
+    cursor = None
 else:
     import yaspin.spinners
     import yaspin.core

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -1,4 +1,5 @@
 # -*- coding=utf-8 -*-
+from __future__ import absolute_import, print_function
 
 import functools
 import os
@@ -23,11 +24,29 @@ except ImportError:
 else:
     from yaspin.spinners import Spinners
 
-handler = None
-if yaspin and os.name == "nt":
-    handler = yaspin.signal_handlers.default_handler
-elif yaspin and os.name != "nt":
-    handler = yaspin.signal_handlers.fancy_handler
+if os.name == "nt":
+    def handler(signum, frame, spinner):
+        """Signal handler, used to gracefully shut down the ``spinner`` instance
+        when specified signal is received by the process running the ``spinner``.
+
+        ``signum`` and ``frame`` are mandatory arguments. Check ``signal.signal``
+        function for more details.
+        """
+        spinner.fail()
+        spinner.stop()
+        sys.exit(0)
+
+else:
+    def handler(signum, frame, spinner):
+        """Signal handler, used to gracefully shut down the ``spinner`` instance
+        when specified signal is received by the process running the ``spinner``.
+
+        ``signum`` and ``frame`` are mandatory arguments. Check ``signal.signal``
+        function for more details.
+        """
+        spinner.red.fail("✘")
+        spinner.stop()
+        sys.exit(0)
 
 CLEAR_LINE = chr(27) + "[K"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,10 @@
 # -*- coding=utf-8 -*-
 import pytest
+from vistir.contextmanagers import replaced_stream
+
+
+@pytest.fixture(scope="function")
+def capture_streams():
+    with replaced_stream("stdout") as stdout:
+        with replaced_stream("stderr") as stderr:
+            yield (stdout, stderr)

--- a/tests/test_contextmanagers.py
+++ b/tests/test_contextmanagers.py
@@ -85,3 +85,11 @@ def test_open_file(tmpdir):
         for chunk in iter(lambda: fp.read(16384), b""):
             local_contents += chunk
     assert local_contents == filecontents.read()
+
+
+def test_replace_stream(capsys):
+    with vistir.contextmanagers.replaced_stream("stdout") as stdout:
+        sys.stdout.write("hello")
+        assert stdout.getvalue() == "hello"
+    out, err = capsys.readouterr()
+    assert out.strip() != "hello"

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -167,6 +167,7 @@ def test_walk_up(tmpdir):
         assert results == expected[i]
 
 
+@settings(deadline=500)
 def test_handle_remove_readonly(tmpdir):
     test_file = tmpdir.join("test_file.txt")
     test_file.write_text("a bunch of text", encoding="utf-8")

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -32,7 +32,7 @@ def test_safe_expandvars():
 
 
 @given(legal_path_chars(), legal_path_chars())
-@settings(suppress_health_check=(HealthCheck.filter_too_much,))
+@settings(suppress_health_check=(HealthCheck.filter_too_much,), deadline=500)
 def test_mkdir_p(base_dir, subdir):
     assume(not any((dir_name in ["", ".", "./", ".."] for dir_name in [base_dir, subdir])))
     assume(not (os.path.relpath(subdir, start=base_dir) == "."))
@@ -167,7 +167,6 @@ def test_walk_up(tmpdir):
         assert results == expected[i]
 
 
-@settings(deadline=500)
 def test_handle_remove_readonly(tmpdir):
     test_file = tmpdir.join("test_file.txt")
     test_file.write_text("a bunch of text", encoding="utf-8")

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,19 +1,30 @@
 # -*- coding=utf-8 -*-
 
-import vistir.spin
+import pytest
+from vistir.contextmanagers import replaced_stream
 import time
 
 
-def test_spinner(capsys):
-    with vistir.spin.create_spinner(spinner_name="bouncingBar", text="Running...", nospin=False) as spinner:
-        time.sleep(3)
-        spinner.ok("Ok!")
-    out, err = capsys.readouterr()
-    assert out.strip().endswith("Ok!")
-    assert err.strip() == ""
-    with vistir.spin.create_spinner(spinner_name="bouncingBar", text="Running...", nospin=False, write_to_stdout=False) as spinner:
-        time.sleep(3)
-        spinner.ok("Ok!")
-    out, err = capsys.readouterr()
-    assert err.strip().endswith("Ok!")
-    assert out.strip() == ""
+@pytest.mark.parametrize("nospin, write_to_stdout", (
+    (True, True), (True, False),
+    (False, True), (False, False)
+))
+def test_spinner(capture_streams, monkeypatch, nospin, write_to_stdout):
+    with replaced_stream("stdout") as stdout:
+        with replaced_stream("stderr") as stderr:
+            with monkeypatch.context() as m:
+                # m.setenv("VISTIR_DISABLE_COLORS", "1")
+                import vistir.spin
+                with vistir.spin.create_spinner(
+                    spinner_name="bouncingBar", text="Running...", nospin=nospin,
+                    write_to_stdout=write_to_stdout
+                ) as spinner:
+                    time.sleep(3)
+                    spinner.ok("Ok!")
+                out = stdout.getvalue().strip(vistir.spin.CLEAR_LINE).strip()
+                err = stderr.getvalue().strip(vistir.spin.CLEAR_LINE).strip()
+                if write_to_stdout:
+                    assert "Ok!" in out.strip().splitlines()[-1], out
+                    assert err.strip() == "", err
+                else:
+                    assert "Ok!" in err.strip().splitlines()[-1], err

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -9,7 +9,7 @@ import time
     (True, True), (True, False),
     (False, True), (False, False)
 ))
-def test_spinner(capture_streams, monkeypatch, nospin, write_to_stdout):
+def test_spinner(monkeypatch, nospin, write_to_stdout):
     with replaced_stream("stdout") as stdout:
         with replaced_stream("stderr") as stderr:
             with monkeypatch.context() as m:


### PR DESCRIPTION
- Also fix a bug with error reporting during `_create_subprocess`
  failures
- Adds a stream wrapper using `TextIOWrapper` via
  `vistir.misc.StreamWrapper`
- Adds `vistir.misc.get_wrapped_stream()` function to wrap existing
  streams
- Adds `vistir.contextmanagers.replaced_stream()` to temporarily replace
  a stream
- Fixes #49
- Closes #48

Signed-off-by: Dan Ryan <dan@danryan.co>