### PR TITLE
Add support for proper filesystem encodings

### DIFF
--- a/news/53.feature.rst
+++ b/news/53.feature.rst
@@ -1,0 +1,1 @@
+Added support for properly encoding and decoding filesystem paths at the boundaries across python versions and platforms.

--- a/src/vistir/__init__.py
+++ b/src/vistir/__init__.py
@@ -32,7 +32,7 @@ from .misc import (
     StreamWrapper
 )
 from .path import mkdir_p, rmtree, create_tracked_tempdir, create_tracked_tempfile
-from .spin import VistirSpinner, create_spinner
+from .spin import create_spinner
 
 
 __version__ = '0.2.6.dev0'
@@ -54,7 +54,6 @@ __all__ = [
     "NamedTemporaryFile",
     "partialmethod",
     "spinner",
-    "VistirSpinner",
     "create_spinner",
     "create_tracked_tempdir",
     "create_tracked_tempfile",

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -261,7 +261,7 @@ def fs_decode(path):
     return path
 
 
-if sys.version_info >= (3, 5) or os.name != "nt":
+if sys.version_info > (3, 5) or os.name != "nt":
     _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 else:
     _fs_encoding = "utf-8"

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -261,14 +261,15 @@ def fs_decode(path):
     return path
 
 
-if sys.version_info >= (3, 3):
+if sys.version_info >= (3, 3) and os.name != "nt":
     _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 else:
     _fs_encoding = "utf-8"
 
 if six.PY3:
     if os.name == "nt":
-        alt_strategy = "surrogatepass"
+        _fs_error_fn = "surrogatepass"
+        alt_strategy = _fs_error_fn
     else:
         alt_strategy = "surrogateescape"
     _fs_error_fn = getattr(sys, "getfilesystemencodeerrors", None)

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -31,7 +31,11 @@ __all__ = [
     "Mapping",
     "Sequence",
     "Set",
-    "ItemsView"
+    "ItemsView",
+    "fs_encode",
+    "fs_decode",
+    "_fs_encode_errors",
+    "_fs_decode_errors"
 ]
 
 if sys.version_info >= (3, 5):
@@ -255,6 +259,7 @@ def fs_decode(path):
     if isinstance(path, six.binary_type):
         path = path.decode(_fs_encoding, _fs_decode_errors)
     return path
+
 
 if sys.version_info >= (3, 5) or os.name != "nt":
     _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -261,7 +261,7 @@ def fs_decode(path):
     return path
 
 
-if sys.version_info > (3, 5) or os.name != "nt":
+if sys.version_info >= (3, 3):
     _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 else:
     _fs_encoding = "utf-8"

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -268,11 +268,11 @@ else:
 
 if six.PY3:
     if os.name == "nt":
-        _fs_error_fn = "surrogatepass"
+        _fs_error_fn = None
         alt_strategy = _fs_error_fn
     else:
         alt_strategy = "surrogateescape"
-    _fs_error_fn = getattr(sys, "getfilesystemencodeerrors", None)
+        _fs_error_fn = getattr(sys, "getfilesystemencodeerrors", None)
     _fs_encode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
     _fs_decode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
 else:

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -211,7 +211,7 @@ def _get_path(path):
     Returns **None** if there is no string value.
     """
 
-    if isinstance(path, six.string_types):
+    if isinstance(path, (str, bytes)):
         return path
     path_type = type(path)
     try:

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -1,6 +1,7 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import codecs
 import errno
 import os
 import sys
@@ -269,8 +270,8 @@ if six.PY3:
     _fs_encode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
     _fs_decode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
 else:
-    _fs_encode_errors = "surrogateescape"
-    _fs_decode_errors = "surrogateescape"
+    _fs_encode_errors = "backslashreplace"
+    _fs_decode_errors = "replace"
 
 
 def to_native_string(string):

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -269,7 +269,7 @@ else:
 if six.PY3:
     if os.name == "nt":
         _fs_error_fn = None
-        alt_strategy = _fs_error_fn
+        alt_strategy = "surrogatepass"
     else:
         alt_strategy = "surrogateescape"
         _fs_error_fn = getattr(sys, "getfilesystemencodeerrors", None)

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -211,14 +211,14 @@ def _get_path(path):
     Returns **None** if there is no string value.
     """
 
-    if isinstance(path, (str, bytes)):
+    if isinstance(path, (six.string_types, bytes)):
         return path
     path_type = type(path)
     try:
         path_repr = path_type.__fspath__(path)
     except AttributeError:
         return
-    if isinstance(path_repr, (str, bytes)):
+    if isinstance(path_repr, (six.string_types, bytes)):
         return path_repr
     return
 

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -255,7 +255,10 @@ def fs_decode(path):
         path = path.decode(_fs_encoding, _fs_decode_errors)
     return path
 
-_fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+if sys.version_info >= (3, 5) or os.name != "nt":
+    _fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+else:
+    _fs_encoding = "utf-8"
 
 if six.PY3:
     if os.name == "nt":
@@ -266,12 +269,8 @@ if six.PY3:
     _fs_encode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
     _fs_decode_errors = _fs_error_fn() if _fs_error_fn is not None else alt_strategy
 else:
-    if os.name == "nt":
-        _fs_encode_errors = "replace"
-        _fs_decode_errors = "escape"
-    else:
-        _fs_encode_errors = "surrogateescape"
-        _fs_decode_errors = "surrogateescape"
+    _fs_encode_errors = "surrogateescape"
+    _fs_decode_errors = "surrogateescape"
 
 
 def to_native_string(string):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -213,19 +213,20 @@ def mkdir_p(newdir, mode=0o777):
     :raises: OSError if a file is encountered along the way
     """
     # http://code.activestate.com/recipes/82465-a-friendly-mkdir/
+    from .compat import to_bytes, to_text
 
-    newdir = fs_encode(newdir)
+    newdir = fs_encode(to_bytes(newdir, encoding="utf-8"))
     if os.path.exists(newdir):
         if not os.path.isdir(newdir):
             raise OSError(
                 "a file with the same name as the desired dir, '{0}', already exists.".format(
-                    newdir
+                    to_text(fs_decode(newdir))
                 )
             )
     else:
         head, tail = os.path.split(newdir)
         # Make sure the tail doesn't point to the asame place as the head
-        curdir = fs_encode(".")
+        curdir = fs_encode(to_bytes(".", encoding="utf-8"))
         tail_and_head_match = (
             os.path.relpath(tail, start=os.path.basename(head)) == curdir
         )
@@ -234,7 +235,7 @@ def mkdir_p(newdir, mode=0o777):
             if os.path.exists(target) and os.path.isfile(target):
                 raise OSError(
                    "A file with the same name as the desired dir, '{0}', already exists.".format(
-                        fs_decode(newdir)
+                        to_text(fs_decode(newdir))
                     )
                 )
             os.makedirs(os.path.join(head, tail), mode)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -215,18 +215,18 @@ def mkdir_p(newdir, mode=0o777):
     # http://code.activestate.com/recipes/82465-a-friendly-mkdir/
     from .misc import to_bytes, to_text
 
-    newdir = fs_encode(to_bytes(newdir, encoding="utf-8"))
+    newdir = fs_encode(newdir)
     if os.path.exists(newdir):
         if not os.path.isdir(newdir):
             raise OSError(
                 "a file with the same name as the desired dir, '{0}', already exists.".format(
-                    to_text(fs_decode(newdir))
+                    fs_decode(newdir)
                 )
             )
     else:
         head, tail = os.path.split(newdir)
         # Make sure the tail doesn't point to the asame place as the head
-        curdir = fs_encode(to_bytes(".", encoding="utf-8"))
+        curdir = fs_encode(".")
         tail_and_head_match = (
             os.path.relpath(tail, start=os.path.basename(head)) == curdir
         )
@@ -235,7 +235,7 @@ def mkdir_p(newdir, mode=0o777):
             if os.path.exists(target) and os.path.isfile(target):
                 raise OSError(
                    "A file with the same name as the desired dir, '{0}', already exists.".format(
-                        to_text(fs_decode(newdir))
+                        fs_decode(newdir)
                     )
                 )
             os.makedirs(os.path.join(head, tail), mode)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -23,6 +23,8 @@ from .compat import (
     TemporaryDirectory,
     _fs_encoding,
     finalize,
+    fs_decode,
+    fs_encode
 )
 
 
@@ -195,9 +197,8 @@ def is_readonly_path(fn):
 
     Permissions check is `bool(path.stat & stat.S_IREAD)` or `not os.access(path, os.W_OK)`
     """
-    from .compat import to_native_string
 
-    fn = to_native_string(fn)
+    fn = fs_encode(fn)
     if os.path.exists(fn):
         file_stat = os.stat(fn).st_mode
         return not bool(file_stat & stat.S_IWRITE) or not os.access(fn, os.W_OK)
@@ -212,9 +213,8 @@ def mkdir_p(newdir, mode=0o777):
     :raises: OSError if a file is encountered along the way
     """
     # http://code.activestate.com/recipes/82465-a-friendly-mkdir/
-    from .misc import to_bytes, to_text
 
-    newdir = to_bytes(newdir, "utf-8")
+    newdir = fs_encode(newdir)
     if os.path.exists(newdir):
         if not os.path.isdir(newdir):
             raise OSError(
@@ -223,9 +223,9 @@ def mkdir_p(newdir, mode=0o777):
                 )
             )
     else:
-        head, tail = os.path.split(to_bytes(newdir, encoding="utf-8"))
+        head, tail = os.path.split(newdir)
         # Make sure the tail doesn't point to the asame place as the head
-        curdir = to_bytes(".", encoding="utf-8")
+        curdir = fs_encode(".")
         tail_and_head_match = (
             os.path.relpath(tail, start=os.path.basename(head)) == curdir
         )
@@ -234,7 +234,7 @@ def mkdir_p(newdir, mode=0o777):
             if os.path.exists(target) and os.path.isfile(target):
                 raise OSError(
                    "A file with the same name as the desired dir, '{0}', already exists.".format(
-                        to_text(newdir, encoding="utf-8")
+                        fs_decode(newdir)
                     )
                 )
             os.makedirs(os.path.join(head, tail), mode)
@@ -296,9 +296,7 @@ def set_write_bit(fn):
     :param str fn: The target filename or path
     """
 
-    from .compat import to_native_string
-
-    fn = to_native_string(fn)
+    fn = fs_encode(fn)
     if not os.path.exists(fn):
         return
     file_stat = os.stat(fn).st_mode
@@ -330,9 +328,7 @@ def rmtree(directory, ignore_errors=False, onerror=None):
        Setting `ignore_errors=True` may cause this to silently fail to delete the path
     """
 
-    from .compat import to_native_string
-
-    directory = to_native_string(directory)
+    directory = fs_encode(directory)
     if onerror is None:
         onerror = handle_remove_readonly
     try:
@@ -361,7 +357,7 @@ def handle_remove_readonly(func, path, exc):
     """
     # Check for read-only attribute
     from .compat import (
-        ResourceWarning, FileNotFoundError, PermissionError, to_native_string
+        ResourceWarning, FileNotFoundError, PermissionError
     )
 
     PERM_ERRORS = (errno.EACCES, errno.EPERM, errno.ENOENT)
@@ -370,7 +366,6 @@ def handle_remove_readonly(func, path, exc):
     )
     # split the initial exception out into its type, exception, and traceback
     exc_type, exc_exception, exc_tb = exc
-    path = to_native_string(path)
     if is_readonly_path(path):
         # Apply write permission and call original function
         set_write_bit(path)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -213,7 +213,7 @@ def mkdir_p(newdir, mode=0o777):
     :raises: OSError if a file is encountered along the way
     """
     # http://code.activestate.com/recipes/82465-a-friendly-mkdir/
-    from .compat import to_bytes, to_text
+    from .misc import to_bytes, to_text
 
     newdir = fs_encode(to_bytes(newdir, encoding="utf-8"))
     if os.path.exists(newdir):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -213,7 +213,6 @@ def mkdir_p(newdir, mode=0o777):
     :raises: OSError if a file is encountered along the way
     """
     # http://code.activestate.com/recipes/82465-a-friendly-mkdir/
-    from .misc import to_bytes, to_text
 
     newdir = fs_encode(newdir)
     if os.path.exists(newdir):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,7 +5,7 @@ import io
 import os
 import stat
 
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, HealthCheck, settings, example
 from six.moves.urllib import parse as urllib_parse
 
 import vistir
@@ -45,6 +45,7 @@ def test_mkdir_p(base_dir, subdir):
 
 
 @given(legal_path_chars(), legal_path_chars())
+@example(base_dir=u'0', subdir=u'\x80')
 @settings(suppress_health_check=(HealthCheck.filter_too_much,))
 def test_ensure_mkdir_p(base_dir, subdir):
     assume(not any((dir_name in ["", ".", "./", ".."] for dir_name in [base_dir, subdir])))

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -40,7 +40,6 @@ def test_mkdir_p(base_dir, subdir):
     with vistir.compat.TemporaryDirectory() as temp_dir:
         target = os.path.join(temp_dir.name, base_dir, subdir)
         assume(vistir.path.abspathu(target) != vistir.path.abspathu(os.path.join(temp_dir.name, base_dir)))
-        target = vistir.misc.to_bytes(target, encoding="utf-8")
         vistir.path.mkdir_p(target)
         assert os.path.exists(target)
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -32,6 +32,7 @@ def test_safe_expandvars():
 
 
 @given(legal_path_chars(), legal_path_chars())
+@example(base_dir=u'0', subdir=u'\x80')
 @settings(suppress_health_check=(HealthCheck.filter_too_much,), deadline=500)
 def test_mkdir_p(base_dir, subdir):
     assume(not any((dir_name in ["", ".", "./", ".."] for dir_name in [base_dir, subdir])))
@@ -41,7 +42,7 @@ def test_mkdir_p(base_dir, subdir):
         target = os.path.join(temp_dir.name, base_dir, subdir)
         assume(vistir.path.abspathu(target) != vistir.path.abspathu(os.path.join(temp_dir.name, base_dir)))
         vistir.path.mkdir_p(target)
-        assert os.path.exists(target)
+        assert os.path.exists(vistir.compat.fs_encode(target))
 
 
 @given(legal_path_chars(), legal_path_chars())
@@ -60,8 +61,7 @@ def test_ensure_mkdir_p(base_dir, subdir):
 
         target = join_with_dir(base_dir, subdir)
         assume(vistir.path.abspathu(target) != vistir.path.abspathu(os.path.join(temp_dir.name, base_dir)))
-        target = vistir.misc.to_bytes(target, encoding="utf-8")
-        assert os.path.exists(target)
+        assert os.path.exists(vistir.compat.fs_encode(target))
 
 
 def test_create_tracked_tempdir(tmpdir):


### PR DESCRIPTION
- Filesystem paths are no longer explicitly bytes encoded
- Encode and decode according to `sys.getfilesystemencoding()`
- Handle errors according to `sys.getfilesystemencodeerrors()` where available
- Use `surrogatepass` on windows+python 3.2+, `replace` when encoding on
  windows+python2, `escape` when decoding on windows+python2
- Use `surrogateescape` on posix when `getfilesystemencodeerrors()` is not available

Signed-off-by: Dan Ryan <dan@danryan.co>