### PR TITLE
rmtree: import FileNotFoundError from compat

### DIFF
--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -331,7 +331,7 @@ def rmtree(directory, ignore_errors=False, onerror=None):
 
        Setting `ignore_errors=True` may cause this to silently fail to delete the path
     """
-
+    from .compat import FileNotFoundError
     directory = fs_encode(directory)
     if onerror is None:
         onerror = handle_remove_readonly


### PR DESCRIPTION
FileNotFoundError does not exist on Python 2.