### PR TITLE
compat: Use import to feature detect

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires =
     wheel
 install_requires =
     colorama
-    backports.functools_lru_cache;python_version<="3.4"
+    backports.functools_lru_cache;python_version<="3.3"
     backports.shutil_get_terminal_size;python_version<"3.3"
     backports.weakref;python_version<"3.3"
     pathlib2;python_version<"3.5"

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -10,7 +10,6 @@ from tempfile import mkdtemp
 
 import six
 
-from .backports.tempfile import NamedTemporaryFile as _NamedTemporaryFile
 
 __all__ = [
     "Path",
@@ -40,19 +39,24 @@ __all__ = [
 
 if sys.version_info >= (3, 5):
     from pathlib import Path
-    from functools import lru_cache
 else:
     from pathlib2 import Path
+
+try:
+    from functools import lru_cache
+except ImportError:
     from backports.functools_lru_cache import lru_cache
 
-
-if sys.version_info < (3, 3):
+try:
+    from shutil import get_terminal_size
+except ImportError:
     from backports.shutil_get_terminal_size import get_terminal_size
 
-    NamedTemporaryFile = _NamedTemporaryFile
+# The Python 2 NamedTemporaryFile doesnt support encoding
+if sys.version_info[0] == 2:
+    from .backports.tempfile import NamedTemporaryFile
 else:
     from tempfile import NamedTemporaryFile
-    from shutil import get_terminal_size
 
 try:
     from weakref import finalize

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -20,7 +20,7 @@ from .compat import (
     ResourceWarning,
     TemporaryDirectory,
     _fs_encoding,
-    _NamedTemporaryFile,
+    NamedTemporaryFile as _NamedTemporaryFile,
     finalize,
     fs_decode,
     fs_encode,


### PR DESCRIPTION
Instead of using literal Python version checks, detect
whether stdlib has the needed function, otherwise fallback
to attempting the backport.

Fixes https://github.com/sarugaku/vistir/issues/63