### PR TITLE
Fix test path generation lengths

### DIFF
--- a/news/65.bugfix.rst
+++ b/news/65.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which caused test failures due to generated paths on *nix based operating systems which were too long.

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -38,6 +38,7 @@ def test_mkdir_p(base_dir, subdir):
     assume(not any((dir_name in ["", ".", "./", ".."] for dir_name in [base_dir, subdir])))
     assume(not (os.path.relpath(subdir, start=base_dir) == "."))
     assume(os.path.abspath(base_dir) != os.path.abspath(os.path.join(base_dir, subdir)))
+    assume(len(base_dir) < 255 and len(subdir) < 255)
     with vistir.compat.TemporaryDirectory() as temp_dir:
         target = os.path.join(temp_dir.name, base_dir, subdir)
         assume(vistir.path.abspathu(target) != vistir.path.abspathu(os.path.join(temp_dir.name, base_dir)))


### PR DESCRIPTION
Fix test path generation lengths

- Include hypothesis assumption of path length `< 255`
- Fixes #65