### PR TITLE
Fix temporary directory rmtree error handler

### DIFF
--- a/news/72.bugfix.rst
+++ b/news/72.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the ``rmtree`` error handler implementation in ``compat.TemporaryDirectory`` which caused cleanup to fail intermittently on windows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = '''
 [tool.towncrier]
 package = 'vistir'
 package_dir = 'src'
-newsfile = 'CHANGELOG.rst'
+filename = 'CHANGELOG.rst'
 directory = 'news/'
 title_format = '{version} ({project_date})'
 issue_format = '`#{issue} <https://github.com/sarugaku/vistir/issues/{issue}>`_'


### PR DESCRIPTION
Fix temporary directory rmtree error handler

- Fixes #72