### PR TITLE
compat: Remove backports from Python 3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ setup_requires =
     wheel
 install_requires =
     colorama>=0.3.4
-    backports.functools_lru_cache;python_version<="3.4"
-    backports.shutil_get_terminal_size;python_version<"3.3"
-    backports.weakref;python_version<"3.3"
+    backports.functools_lru_cache;python_version=="2.7"
+    backports.shutil_get_terminal_size;python_version=="2.7"
+    backports.weakref;python_version=="2.7"
     pathlib2;python_version<"3.5"
     requests
     six

--- a/src/vistir/compat.py
+++ b/src/vistir/compat.py
@@ -42,33 +42,27 @@ __all__ = [
 
 if sys.version_info >= (3, 5):
     from pathlib import Path
-    from functools import lru_cache
 else:
     from pathlib2 import Path
-    from backports.functools_lru_cache import lru_cache
 
-
-if sys.version_info < (3, 3):
-    from backports.shutil_get_terminal_size import get_terminal_size
-
-    NamedTemporaryFile = _NamedTemporaryFile
-else:
+if six.PY3:
+    # Only Python 3.4+ is supported
+    from functools import lru_cache, partialmethod
     from tempfile import NamedTemporaryFile
     from shutil import get_terminal_size
-
-try:
     from weakref import finalize
-except ImportError:
+else:
+    # Only Python 2.7 is supported
+    from backports.functools_lru_cache import lru_cache
+    from .backports.functools import partialmethod  # type: ignore
+    from backports.shutil_get_terminal_size import get_terminal_size
+    NamedTemporaryFile = _NamedTemporaryFile
     from backports.weakref import finalize  # type: ignore
 
 try:
-    from functools import partialmethod
-except Exception:
-    from .backports.functools import partialmethod  # type: ignore
-
-try:
+    # Introduced Python 3.5
     from json import JSONDecodeError
-except ImportError:  # Old Pythons.
+except ImportError:
     JSONDecodeError = ValueError  # type: ignore
 
 if six.PY2:


### PR DESCRIPTION
Remove complex version markers and runtime version checking
for unsupported versions between Python 2.7 and Python 3.4+.
The logic was wrong, requiring backports.functools_lru_cache
on Python 3.4 when the stdlib function was acceptable.

Fixes https://github.com/sarugaku/vistir/issues/63