### PR TITLE
Fix backport fsencode reference

### DIFF
--- a/news/74.bugfix.rst
+++ b/news/74.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where paths could sometimes fail to be fs-encoded properly when using backported ``NamedTemporaryFile`` instances.

--- a/src/vistir/backports/tempfile.py
+++ b/src/vistir/backports/tempfile.py
@@ -15,6 +15,24 @@ except ImportError:
     from backports.weakref import finalize
 
 
+def fs_encode(path):
+    try:
+        return os.fsencode(path)
+    except AttributeError:
+        from ..compat import fs_encode
+
+        return fs_encode(path)
+
+
+def fs_decode(path):
+    try:
+        return os.fsdecode(path)
+    except AttributeError:
+        from ..compat import fs_decode
+
+        return fs_decode(path)
+
+
 __all__ = ["finalize", "NamedTemporaryFile"]
 
 
@@ -48,7 +66,7 @@ def _sanitize_params(prefix, suffix, dir):
         if output_type is str:
             dir = gettempdir()
         else:
-            dir = os.fsencode(gettempdir())
+            dir = fs_encode(gettempdir())
     return prefix, suffix, dir, output_type
 
 

--- a/test_compat.py
+++ b/test_compat.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from vistir.compat import fs_decode, fs_encode
+
+
+def test_fs_encode():
+    # This fails in the normal backports library:
+    # see https://github.com/PiDelport/backports.os/issues/13
+    assert fs_decode(fs_encode(u"unicode\u0141")) == u"unicode\u0141"


### PR DESCRIPTION
- Fixes #74
- add fsencode and fsdecode test

Signed-off-by: Dan Ryan <dan@danryan.co>