### PR TITLE
* Replace to locale.getdefaultlocale because there is no locale.getdefaultencoding

### DIFF
--- a/news/78.bugfix.rst
+++ b/news/78.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``vistir.misc.locale_encoding`` which caused invocation of a non-existent method called ``getlocaleencoding`` which forced all systems to use default encoding of ``ascii``.

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -514,7 +514,7 @@ def chunked(n, iterable):
 
 
 try:
-    locale_encoding = locale.getdefaultencoding()[1] or "ascii"
+    locale_encoding = locale.getdefaultlocale()[1] or "ascii"
 except Exception:
     locale_encoding = "ascii"
 


### PR DESCRIPTION
The issue
According to the existing code, locale_encoding of 302 line is fixed as ascii, and it does not follow system encoding value.
It can be a bug in an area that uses encoding in other languages ​​not English.

The fix
replace locale.getdefaultlocale with locale.getdefaultencoding because locale.getdefaultencoding is not exist