### PR TITLE
Fix stream color wrappers on windows

### DIFF
--- a/news/88.bugfix.rst
+++ b/news/88.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue which caused color wrapping of standard streams on windows to fail to surface critical attributes.

--- a/src/vistir/_winconsole.py
+++ b/src/vistir/_winconsole.py
@@ -39,30 +39,32 @@
 # the entire interpreter but just work in our little world of
 # echo and prmopt.
 
+import ctypes
 import io
 import os
 import sys
-import zlib
 import time
-import ctypes
-import msvcrt
+import zlib
 from ctypes import (
-    byref,
     POINTER,
-    c_int,
+    WINFUNCTYPE,
+    Structure,
+    byref,
     c_char,
     c_char_p,
-    c_void_p,
+    c_int,
     c_ssize_t,
     c_ulong,
+    c_void_p,
     py_object,
-    Structure,
     windll,
-    WINFUNCTYPE,
 )
-from ctypes.wintypes import LPWSTR, LPCWSTR
+from ctypes.wintypes import LPCWSTR, LPWSTR
 from itertools import count
+
+import msvcrt
 from six import PY2, text_type
+
 from .misc import StreamWrapper, run
 
 try:
@@ -231,6 +233,10 @@ class ConsoleStream(object):
     @property
     def name(self):
         return self.buffer.name
+
+    @property
+    def fileno(self):
+        return self.buffer.fileno
 
     def write(self, x):
         if isinstance(x, text_type):

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -741,14 +741,16 @@ class StreamWrapper(io.TextIOWrapper):
 
         def write(self, x):
             # try to use backslash and surrogate escape strategies before failing
-            old_errors = getattr(self, "_errors", self.errors)
             self._errors = (
                 "backslashescape" if self.encoding != "mbcs" else "surrogateescape"
             )
             try:
                 return io.TextIOWrapper.write(self, to_text(x, errors=self._errors))
             except UnicodeDecodeError:
-                self._errors = old_errors
+                if self._errors != "surrogateescape":
+                    self._errors = "surrogateescape"
+                else:
+                    self._errors = "replace"
                 return io.TextIOWrapper.write(self, to_text(x, errors=self._errors))
 
         def writelines(self, lines):
@@ -841,6 +843,11 @@ if os.name == "nt" or sys.platform.startswith("win"):
 
     if colorama is not None:
 
+        def _is_wrapped_for_color(stream):
+            return isinstance(
+                stream, (colorama.AnsiToWin32, colorama.ansitowin32.StreamWrapper)
+            )
+
         def _wrap_for_color(stream, color=None):
             try:
                 cached = _color_stream_cache.get(stream)
@@ -911,6 +918,8 @@ def get_text_stream(stream="stdout", encoding=None):
     sys_stream = stream_map[stream]
     windows_console = _get_windows_console_stream(sys_stream, encoding, None)
     if windows_console is not None:
+        if _can_use_color(windows_console):
+            return _wrap_for_color(windows_console)
         return windows_console
     return get_wrapped_stream(sys_stream, encoding)
 
@@ -927,16 +936,12 @@ def get_text_stdin():
     return get_text_stream("stdin")
 
 
-TEXT_STREAMS = {
-    "stdin": get_text_stdin,
-    "stdout": get_text_stdout,
-    "stderr": get_text_stderr,
-}
-
-
 _text_stdin = _cached_stream_lookup(lambda: sys.stdin, get_text_stdin)
 _text_stdout = _cached_stream_lookup(lambda: sys.stdout, get_text_stdout)
 _text_stderr = _cached_stream_lookup(lambda: sys.stderr, get_text_stderr)
+
+
+TEXT_STREAMS = {"stdin": _text_stdin, "stdout": _text_stdout, "stderr": _text_stderr}
 
 
 def replace_with_text_stream(stream_name):
@@ -1009,7 +1014,7 @@ def echo(text, fg=None, bg=None, style=None, file=None, err=False, color=None):
             text = colorize(text, fg=fg, bg=bg, attrs=style)
         if not can_use_color or (os.name == "nt" and not _wrap_for_color):
             text = ANSI_REMOVAL_RE.sub("", text)
-        elif os.name == "nt" and _wrap_for_color:
+        elif os.name == "nt" and _wrap_for_color and not _is_wrapped_for_color(file):
             file = _wrap_for_color(file, color=color)
     if text:
         file.write(text)

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -941,7 +941,11 @@ _text_stdout = _cached_stream_lookup(lambda: sys.stdout, get_text_stdout)
 _text_stderr = _cached_stream_lookup(lambda: sys.stderr, get_text_stderr)
 
 
-TEXT_STREAMS = {"stdin": _text_stdin, "stdout": _text_stdout, "stderr": _text_stderr}
+TEXT_STREAMS = {
+    "stdin": get_text_stdin,
+    "stdout": get_text_stdout,
+    "stderr": get_text_stderr,
+}
 
 
 def replace_with_text_stream(stream_name):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -345,7 +345,7 @@ def set_write_bit(fn):
         from .misc import run
 
         if user_sid:
-            _, err = run(
+            c = run(
                 [
                     icacls_exe,
                     "''{0}''".format(fn),
@@ -354,9 +354,11 @@ def set_write_bit(fn):
                     "/T",
                     "/C",
                     "/Q",
-                ]
+                ],
+                nospin=True,
+                return_object=True,
             )
-            if not err:
+            if not c.err and c.returncode == 0:
                 return
 
     if not os.path.isdir(fn):


### PR DESCRIPTION
- Pass `fileno` correctly to `ConsoleWrapper`
- Fix encoding fallbacks for `StreamWrapper`
- Don't re-wrap streams that are already wrapped for color
- Fixes #88

Signed-off-by: Dan Ryan <dan@danryan.co>