### PR TITLE
Add function to expand shortened paths on windows

### DIFF
--- a/news/90.feature.rst
+++ b/news/90.feature.rst
@@ -1,0 +1,1 @@
+Shortened windows paths will now be properly resolved to the full path by ``vistir.path.normalize_path``.

--- a/src/vistir/_winconsole.py
+++ b/src/vistir/_winconsole.py
@@ -56,6 +56,7 @@ from ctypes import (
     c_ssize_t,
     c_ulong,
     c_void_p,
+    create_unicode_buffer,
     py_object,
     windll,
 )
@@ -65,7 +66,8 @@ from itertools import count
 import msvcrt
 from six import PY2, text_type
 
-from .misc import StreamWrapper, run
+from .compat import IS_TYPE_CHECKING
+from .misc import StreamWrapper, run, to_text
 
 try:
     from ctypes import pythonapi
@@ -74,6 +76,10 @@ try:
     PyBuffer_Release = pythonapi.PyBuffer_Release
 except ImportError:
     pythonapi = None
+
+
+if IS_TYPE_CHECKING:
+    from typing import Text
 
 
 c_ssize_p = POINTER(c_ssize_t)
@@ -155,6 +161,15 @@ else:
             return buffer_type.from_address(buf.buf)
         finally:
             PyBuffer_Release(byref(buf))
+
+
+def get_long_path(short_path):
+    # type: (Text, str) -> Text
+    BUFFER_SIZE = 500
+    buffer = create_unicode_buffer(BUFFER_SIZE)
+    get_long_path_name = windll.kernel32.GetLongPathNameW
+    get_long_path_name(to_text(short_path), buffer, BUFFER_SIZE)
+    return buffer.value
 
 
 class _WindowsConsoleRawIOBase(io.RawIOBase):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -103,16 +103,13 @@ def normalize_path(path):
     :rtype: str
     """
 
+    path = os.path.abspath(os.path.expandvars(os.path.expanduser(str(path))))
     if os.name == "nt":
         from ._winconsole import get_long_path
 
         path = get_long_path(path)
 
-    return os.path.normpath(
-        os.path.normcase(
-            os.path.abspath(os.path.expandvars(os.path.expanduser(str(path))))
-        )
-    )
+    return os.path.normpath(os.path.normcase(path))
 
 
 def is_in_path(path, parent):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -104,7 +104,7 @@ def normalize_path(path):
     """
 
     path = os.path.abspath(os.path.expandvars(os.path.expanduser(str(path))))
-    if os.name == "nt":
+    if os.name == "nt" and os.path.exists(path):
         from ._winconsole import get_long_path
 
         path = get_long_path(path)

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -103,6 +103,11 @@ def normalize_path(path):
     :rtype: str
     """
 
+    if os.name == "nt":
+        from ._winconsole import get_long_path
+
+        path = get_long_path(path)
+
     return os.path.normpath(
         os.path.normcase(
             os.path.abspath(os.path.expandvars(os.path.expanduser(str(path))))


### PR DESCRIPTION
- Shortened windows paths should be expanded by `normalize_path`
- Fixes #90

Signed-off-by: Dan Ryan <dan@danryan.co>