### PR TITLE
Fix deadlock / race conditions on windows

### DIFF
--- a/news/95.bugfix.rst
+++ b/news/95.bugfix.rst
@@ -1,0 +1,1 @@
+Exceptions are no longer suppressed after being handled during ``vistir.misc.run``.

--- a/news/96.bugfix.rst
+++ b/news/96.bugfix.rst
@@ -1,0 +1,1 @@
+The signal handler for ``VistirSpinner`` will no longer cause deadlocks when ``CTRL_BREAK_EVENTS`` occur on windows.

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -302,9 +302,10 @@ def _create_subprocess(
     else:
         try:
             c.out, c.err = c.communicate()
-        except (SystemExit, TimeoutError):
+        except (SystemExit, KeyboardInterrupt, TimeoutError):
             c.terminate()
             c.out, c.err = c.communicate()
+            raise
     if not block:
         c.wait()
     c.out = to_text("{0}".format(c.out)) if c.out else fs_str("")

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -41,7 +41,6 @@ if os.name == "nt":  # pragma: no cover
         """
         spinner.fail()
         spinner.stop()
-        sys.exit(0)
 
 
 else:  # pragma: no cover
@@ -55,7 +54,6 @@ else:  # pragma: no cover
         """
         spinner.red.fail("✘")
         spinner.stop()
-        sys.exit(0)
 
 
 CLEAR_LINE = chr(27) + "[K"


### PR DESCRIPTION
- Fix deadlock when fielding `CTRL_BREAK_EVENT` while spinner is running
- Fix failure to raise handled exceptions in `vistir.misc.run`
- Fixes #95
- Fixes #96

Signed-off-by: Dan Ryan <dan@danryan.co>