### PR TITLE
Account for encoded length when limiting path components

### DIFF
--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -68,6 +68,8 @@ def test_mkdir_p(base_dir, subdir):
     assume(not (os.path.relpath(subdir, start=base_dir) == "."))
     assume(os.path.abspath(base_dir) != os.path.abspath(os.path.join(base_dir, subdir)))
     assume(len(base_dir) < 255 and len(subdir) < 255)
+    assume(len(vistir.compat.fs_encode(subdir)) < 255)
+    assume(len(vistir.compat.fs_encode(base_dir)) < 255)
     with vistir.compat.TemporaryDirectory() as temp_dir:
         target = os.path.join(temp_dir.name, base_dir, subdir)
         assume(


### PR DESCRIPTION
A single UTF-8 character may be encoded to several bytes. For Linux,
the typical maximum component length is 255 bytes.

This should fix occasional failures like #65.