### PR TITLE
Fix surrogate handler for filename->url conversion

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -627,7 +627,7 @@
                 "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db",
                 "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
             ],
-            "markers": "python_version < '3.5'",
+            "markers": "python_version < '3.6'",
             "version": "==2.3.5"
         },
         "pathspec": {

--- a/news/100.bugfix.rst
+++ b/news/100.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which caused ``path_to_url`` to sometimes fail to properly encode surrogates using utf-8 on windows using python 3.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     backports.functools_lru_cache;python_version=="2.7"
     backports.shutil_get_terminal_size;python_version=="2.7"
     backports.weakref;python_version=="2.7"
-    pathlib2;python_version<"3.5"
+    pathlib2;python_version<"3.6"
     six
 
 [options.extras_require]

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -30,6 +30,14 @@ from .compat import (
     fs_encode,
 )
 
+# fmt: off
+if six.PY3:
+    from urllib.parse import quote_from_bytes as quote
+else:
+    from urllib import quote
+# fmt: on
+
+
 if IS_TYPE_CHECKING:
     from typing import Optional, Callable, Text, ByteString, AnyStr
 
@@ -158,13 +166,23 @@ def path_to_url(path):
     >>> path_to_url("/home/user/code/myrepo/myfile.zip")
     'file:///home/user/code/myrepo/myfile.zip'
     """
-    from .misc import to_text, to_bytes
+    from .misc import to_bytes
 
     if not path:
         return path
-    path = to_bytes(path, encoding="utf-8")
-    normalized_path = to_text(normalize_drive(os.path.abspath(path)), encoding="utf-8")
-    return to_text(Path(normalized_path).as_uri(), encoding="utf-8")
+    normalized_path = Path(normalize_drive(os.path.abspath(path))).as_posix()
+    if os.name == "nt" and normalized_path.as_posix()[1] == ":":
+        drive, _, path = normalized_path.as_posix().partition(":")
+        # XXX: This enables us to handle half-surrogates that were never
+        # XXX: actually part of a surrogate pair, but were just incidentally
+        # XXX: passed in as a piece of a filename
+        quoted_path = quote(fs_encode(path))
+        return fs_decode("file:///{0}/{1}".format(drive, quoted_path))
+    # XXX: This is also here to help deal with incidental dangling surrogates
+    # XXX: on linux, by making sure they are preserved during encoding so that
+    # XXX: we can urlencode the backslash correctly
+    bytes_path = to_bytes(normalized_path, errors="backslashreplace")
+    return fs_decode("file://{0}".format(quote(bytes_path)))
 
 
 def url_to_path(url):
@@ -174,7 +192,6 @@ def url_to_path(url):
 
     Follows logic taken from pip's equivalent function
     """
-    from .misc import to_bytes
 
     assert is_file_url(url), "Only file: urls can be converted to local paths"
     _, netloc, path, _, _ = urllib_parse.urlsplit(url)
@@ -183,7 +200,7 @@ def url_to_path(url):
         netloc = "\\\\" + netloc
 
     path = urllib_request.url2pathname(netloc + path)
-    return to_bytes(path, encoding="utf-8")
+    return urllib_parse.unquote(path)
 
 
 def is_valid_url(url):

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -171,8 +171,8 @@ def path_to_url(path):
     if not path:
         return path
     normalized_path = Path(normalize_drive(os.path.abspath(path))).as_posix()
-    if os.name == "nt" and normalized_path.as_posix()[1] == ":":
-        drive, _, path = normalized_path.as_posix().partition(":")
+    if os.name == "nt" and normalized_path[1] == ":":
+        drive, _, path = normalized_path.partition(":")
         # XXX: This enables us to handle half-surrogates that were never
         # XXX: actually part of a surrogate pair, but were just incidentally
         # XXX: passed in as a piece of a filename

--- a/src/vistir/path.py
+++ b/src/vistir/path.py
@@ -177,7 +177,7 @@ def path_to_url(path):
         # XXX: actually part of a surrogate pair, but were just incidentally
         # XXX: passed in as a piece of a filename
         quoted_path = quote(fs_encode(path))
-        return fs_decode("file:///{0}/{1}".format(drive, quoted_path))
+        return fs_decode("file:///{0}:{1}".format(drive, quoted_path))
     # XXX: This is also here to help deal with incidental dangling surrogates
     # XXX: on linux, by making sure they are preserved during encoding so that
     # XXX: we can urlencode the backslash correctly

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -196,6 +196,7 @@ def test_is_file_url_raises_valueerror_when_no_url_attribute_found():
 
 
 @given(fspaths())
+@example("0\ud800")
 @settings(suppress_health_check=(HealthCheck.filter_too_much,))
 def test_path_to_url(filepath):
     class FakeLink(object):


### PR DESCRIPTION
- Use appropriate error-handling encoders and directly urlencode paths before
  converting to a `file://` url
- Vistir's compat filesystem encoding will allow us to manage the
  surrogates properly on windows during the decoding step
- Added additional functionality for `url_to_path` conversions to make
  sure we unquote urls that may have been quoted here
- Fixes #100

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>