### PR TITLE
Add deprecation warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,22 +95,6 @@ You can import utilities directly from **vistir**:
     * Miscellaneous Utilities
     * Path Utilities
 
-
-🐉 Compatibility Shims
------------------------
-
-Shims are provided for full API compatibility from python 2.7 through 3.7 for the following:
-
-    * ``weakref.finalize``
-    * ``vistir.compat.Path``
-    * ``vistir.compat.get_terminal_size``
-    * ``vistir.compat.JSONDecodeError``
-    * ``vistir.compat.ResourceWarning``
-    * ``vistir.compat.FileNotFoundError``
-    * ``vistir.compat.PermissionError``
-    * ``vistir.compat.IsADirectoryError``
-
-
 🐉 Context Managers
 --------------------
 
@@ -121,7 +105,6 @@ Shims are provided for full API compatibility from python 2.7 through 3.7 for th
     * ``vistir.contextmanagers.open_file``
     * ``vistir.contextmanagers.replaced_stream``
     * ``vistir.contextmanagers.replaced_streams``
-    * ``vistir.contextmanagers.spinner``
     * ``vistir.contextmanagers.temp_environ``
     * ``vistir.contextmanagers.temp_path``
 

--- a/README.rst
+++ b/README.rst
@@ -350,15 +350,12 @@ The following Miscellaneous utilities are available as helper methods:
 
     * ``vistir.misc.shell_escape``
     * ``vistir.misc.unnest``
-    * ``vistir.misc.dedup``
     * ``vistir.misc.run``
     * ``vistir.misc.load_path``
     * ``vistir.misc.partialclass``
     * ``vistir.misc.to_text``
     * ``vistir.misc.to_bytes``
-    * ``vistir.misc.divide``
     * ``vistir.misc.take``
-    * ``vistir.misc.chunked``
     * ``vistir.misc.decode_for_output``
     * ``vistir.misc.get_canonical_encoding_name``
     * ``vistir.misc.get_wrapped_stream``

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import threading
 import typing
+import warnings
+
 from collections import OrderedDict
 from functools import partial
 from itertools import islice, tee
@@ -135,6 +137,11 @@ def dedup(iterable):
     # type: (Iterable) -> Iterable
     """Deduplicate an iterable object like iter(set(iterable)) but order-
     preserved."""
+    warnings.warn(
+        ('This function is deprecated and will be removed in version 0.8.'
+         'Use instead: sorted(iter(dict.fromkeys(iterable)))'),
+        DeprecationWarning, stacklevel=2)
+
     return iter(OrderedDict.fromkeys(iterable))
 
 

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -807,6 +807,11 @@ def take(n, iterable):
     from https://github.com/erikrose/more-itertools/blob/master/more_itertools/recipes.py
     """
 
+    warnings.warn(
+        ('This function is deprecated and will be removed in version 0.8.'
+         'Use instead: list(islice(iterable, n))'),
+        DeprecationWarning, stacklevel=2)
+
     return list(islice(iterable, n))
 
 

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -818,6 +818,10 @@ def chunked(n, iterable):
 
     from https://github.com/erikrose/more-itertools/blob/master/more_itertools/more.py
     """
+    warnings.warn(
+        ('This function is deprecated and will be removed in version 0.8.'
+         'Use instead: more_itertools.chunked(iterable, n)))'),
+        DeprecationWarning, stacklevel=2)
 
     return iter(partial(take, n, iter(iterable)), [])
 

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -642,6 +642,9 @@ def load_path(python):
      '/home/user/.virtualenvs/requirementslib-5MhGuG3C/lib/python3.7/site-packages',
      '/home/user/git/requirementslib/src']
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in version 0.8.',
+        DeprecationWarning, stacklevel=2)
     from pathlib import Path
     python = Path(python).as_posix()
     out, err = run(

--- a/src/vistir/misc.py
+++ b/src/vistir/misc.py
@@ -782,7 +782,10 @@ def divide(n, iterable):
     :return: a list of new iterables derived from the original iterable
     :rtype: list
     """
-
+    warnings.warn(
+        ('This function is deprecated and will be removed in version 0.8.'
+         'Use instead: more_itertools.divide(n, iterable)))'),
+        DeprecationWarning, stacklevel=2)
     seq = tuple(iterable)
     q, r = divmod(len(seq), n)
 

--- a/src/vistir/spin.py
+++ b/src/vistir/spin.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import time
 import typing
+import warnings
+
 from io import StringIO
 
 import colorama
@@ -36,16 +38,16 @@ if typing.TYPE_CHECKING:
 
 try:
     import yaspin
-except ImportError:  # pragma: no cover
-    yaspin = None
-    Spinners = None
-    SpinBase = None
-else:  # pragma: no cover
     import yaspin.spinners
     import yaspin.core
 
     Spinners = yaspin.spinners.Spinners
     SpinBase = yaspin.core.Yaspin
+
+except ImportError:  # pragma: no cover
+    yaspin = None
+    Spinners = None
+    SpinBase = None
 
 if os.name == "nt":  # pragma: no cover
 
@@ -482,6 +484,10 @@ class VistirSpinner(SpinBase):
 
 
 def create_spinner(*args, **kwargs):
+     warnings.warn(
+        ('This function is deprecated and will be removed in version 0.8.'
+         'Consider using yaspin directly instead, or user rich.status'),
+        DeprecationWarning, stacklevel=2)
     # type: (Any, Any) -> Union[DummySpinner, VistirSpinner]
     nospin = kwargs.pop("nospin", False)
     use_yaspin = kwargs.pop("use_yaspin", not nospin)


### PR DESCRIPTION
Remove a few functions that are either simply copied from other libraries or can be easily replaced with a one-liner. 